### PR TITLE
Update to Firefox Beta and include Chrome Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,20 @@ Quickstart
 
 Important Notes
 ---------------
-Currently WebAuthn only works in [Firefox's Beta Build](https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=en-US)
-After installing:
+Currently WebAuthn only works in [Firefox's Beta Build](https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=en-US) or [Chrome's Dev 
+Channel](https://www.chromium.org/getting-involved/dev-channel) (U2F tokens only in Chrome)  
+After installing:  
+  
+Firefox:
 1. Open the Firefox advanced preferences at the URL (about:config)[about:config]. These are feature flags for FF Nightly.
 2. Search for "webauth"
 3. Enable `value=True` for:
 * `security.webauth.webauthn`
 4. Reload the page and you're ready to go!
-
-
-
+  
+Chrome:
+1. Open the Chrome experimental features page at the URL(chrome://flags)[chrome://flags]. These are feature flags for Chrome.
+2. Search for "Web Authentication"
+3. Change `Web Authentication API` to `Enabled`
+4. Restart Chrome and you're ready to go!
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,7 @@ Important Notes
 ---------------
 Currently WebAuthn only works in [Firefox's Beta Build](https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=en-US) or [Chrome's Dev 
 Channel](https://www.chromium.org/getting-involved/dev-channel) (U2F tokens only in Chrome)  
-After installing:  
-  
-Firefox:
-1. Open the Firefox advanced preferences at the URL [about:config](about:config). These are feature flags for FF.
-2. Search for "webauth"
-3. Enable `value=True` for:
-* `security.webauth.webauthn`
-4. Reload the page and you're ready to go!
-  
-Chrome:
+Special instructions for Chrome:
 1. Open the Chrome experimental features page at the URL [chrome://flags](chrome://flags). These are feature flags for Chrome.
 2. Search for "Web Authentication"
 3. Change `Web Authentication API` to `Enabled`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quickstart
 
 Important Notes
 ---------------
-Currently WebAuthn only works in [Firefox's Nightly Build](https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=osx&lang=en-US)
+Currently WebAuthn only works in [Firefox's Beta Build](https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=osx&lang=en-US)
 After installing:
 1. Open the Firefox advanced preferences at the URL (about:config)[about:config]. These are feature flags for FF Nightly.
 2. Search for "webauth"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Channel](https://www.chromium.org/getting-involved/dev-channel) (U2F tokens only
 After installing:  
   
 Firefox:
-1. Open the Firefox advanced preferences at the URL (about:config)[about:config]. These are feature flags for FF Nightly.
+1. Open the Firefox advanced preferences at the URL (about:config)[about:config]. These are feature flags for FF.
 2. Search for "webauth"
 3. Enable `value=True` for:
 * `security.webauth.webauthn`

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Channel](https://www.chromium.org/getting-involved/dev-channel) (U2F tokens only
 After installing:  
   
 Firefox:
-1. Open the Firefox advanced preferences at the URL (about:config)[about:config]. These are feature flags for FF.
+1. Open the Firefox advanced preferences at the URL [about:config](about:config). These are feature flags for FF.
 2. Search for "webauth"
 3. Enable `value=True` for:
 * `security.webauth.webauthn`
 4. Reload the page and you're ready to go!
   
 Chrome:
-1. Open the Chrome experimental features page at the URL(chrome://flags)[chrome://flags]. These are feature flags for Chrome.
+1. Open the Chrome experimental features page at the URL [chrome://flags](chrome://flags). These are feature flags for Chrome.
 2. Search for "Web Authentication"
 3. Change `Web Authentication API` to `Enabled`
 4. Restart Chrome and you're ready to go!

--- a/templates/login.html
+++ b/templates/login.html
@@ -25,13 +25,22 @@
             <div class="login-wrapper">
                 <form class="form-signin">
                     <h2 class="form-signin-heading text-center">WebAuthn.io</h2>                    
-                    <p>Currently, WebAuthn is only available to test on <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/">Firefox's Nightly Build</a></p>
-                    <p>Once you've installed the Nightly Build:</p>
+                    <p>Currently, WebAuthn is only available to test on <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/">Firefox's Beta Build</a> and <a href="https://www.chromium.org/getting-involved/dev-channel">Chrome's Dev Channel</a></p>
+                    <p>Once you've installed a compatible browser:</p>
+                    <p>Firefox Beta:</p>
                     <ol>
                         <li>Open the Firefox advanced preference panel at <a href="about:config">about:config</a></li>
                         <li>Search for "webauthn" to find the WebAuthn related feature flags</li>
                         <li>Set the value for <code>security.webauth.webauthn</code> to <code>true</code></li>
                         <li>Reload this page and register or login to an account.</li>
+                        <li>Get excited for WebAuthn!</li>
+                    </ol>
+                    <p>Chrome Dev:</p>
+                    <ol>
+                        <li>Open the Chrome experimental features page at <a href="chrome://flags">chrome://flags</a></li>
+                        <li>Search for "Web Auth" to find the WebAuthn related feature flags</li>
+                        <li>Change the value for <code>Web Authentication API</code> to <code>Enabled</code></li>
+                        <li>Restart Chrome and register or login to an account.</li>
                         <li>Get excited for WebAuthn!</li>
                     </ol>
                     <div class="row">

--- a/templates/login.html
+++ b/templates/login.html
@@ -26,16 +26,7 @@
                 <form class="form-signin">
                     <h2 class="form-signin-heading text-center">WebAuthn.io</h2>                    
                     <p>Currently, WebAuthn is only available to test on <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/">Firefox's Beta Build</a> and <a href="https://www.chromium.org/getting-involved/dev-channel">Chrome's Dev Channel</a></p>
-                    <p>Once you've installed a compatible browser:</p>
-                    <p>Firefox Beta:</p>
-                    <ol>
-                        <li>Open the Firefox advanced preference panel at <a href="about:config">about:config</a></li>
-                        <li>Search for "webauthn" to find the WebAuthn related feature flags</li>
-                        <li>Set the value for <code>security.webauth.webauthn</code> to <code>true</code></li>
-                        <li>Reload this page and register or login to an account.</li>
-                        <li>Get excited for WebAuthn!</li>
-                    </ol>
-                    <p>Chrome Dev:</p>
+                    <p>Special instructions for Chrome:</p>
                     <ol>
                         <li>Open the Chrome experimental features page at <a href="chrome://flags">chrome://flags</a></li>
                         <li>Search for "Web Auth" to find the WebAuthn related feature flags</li>

--- a/templates/winlogin.html
+++ b/templates/winlogin.html
@@ -25,7 +25,8 @@
                 <form class="form-signin">
                     <h2 class="form-signin-heading text-center">WebAuthn.io <i>Hello</i></h2>
                     <h4>Warning: This is a <i>extremely</i> basic build of WebAuthn available using Windows Hello and Edge Browser! It is very out of date!</h4> 
-                    <p>I highly recommend using the version of Webauthn available <a href="/">here</a> using <a href="https://www.mozilla.org/en-US/firefox/channel/desktop/">Firefox's Nightly Build</a></p>
+                    <p>I highly recommend using the version of Webauthn available <a href="/">here</a> using <a 
+href="https://www.mozilla.org/en-US/firefox/channel/desktop/">Firefox's Beta Build</a></p>
                     <p>Things to note about this build:</p>
                     <ol>
                         <li>It will only work on the <a href="https://www.microsoft.com/en-us/windows/microsoft-edge">Edge Browser</a> on a Windows Hello capable PC</li>


### PR DESCRIPTION
This PR updates all pages to refer to Firefox Beta instead of Nightly, and includes Chrome Dev in the readme and the login page.