### PR TITLE
Add RS256 for Windows Hello support

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,6 +121,10 @@ func RequestNewCredential(w http.ResponseWriter, r *http.Request) {
 			Type:      "public-key",
 			Algorithm: "-7",
 		},
+		res.CredentialParameter{
+			Type:      "public-key",
+			Algorithm: "-257", // RS256 for Windows Hello
+		},
 	}
 
 	// Get the proper URL the request is coming from


### PR DESCRIPTION
As [documented by Microsoft](https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/windows-integration/web-authentication), Edge's support for Microsoft's Windows Hello biometric authentication requires RS256 to be listed as an algo on credentials.