### PR TITLE
Add support for RSA keys and TPM attestation type.

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -2,9 +2,7 @@ package protocol
 
 import (
 	"crypto/sha256"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"net/http"
 )
@@ -104,27 +102,26 @@ func (p *ParsedCredentialAssertionData) Verify(storedChallenge []byte, relyingPa
 	// Step 16. Using the credential public key looked up in step 3, verify that sig is
 	// a valid signature over the binary concatenation of authData and hash.
 
-	// Put this into proper certificate format for Step 16
-	pemBlock, _ := pem.Decode(credentialBytes)
-	if pemBlock == nil {
-		return ErrParsingData.WithDetails("Unable to decode stored public key credential")
-	}
-
-	parsedKey, err := x509.ParsePKIXPublicKey(pemBlock.Bytes)
-	if err != nil {
-		return ErrParsingData.WithDetails("Unable to parse pem decoded public key").WithInfo(err.Error())
-	}
-
-	credentialCertificate := x509.Certificate{PublicKey: parsedKey}
-
 	sigData := append(p.Raw.AssertionResponse.AuthenticatorData, clientDataHash[:]...)
 
-	// For COSE Key signature validation, we currently use ECDSA w/ SHA-256 primarily
-	invalidSigError := credentialCertificate.CheckSignature(x509.ECDSAWithSHA256, sigData, p.Response.Signature)
-	if invalidSigError != nil {
-		fmt.Println("returned error:", invalidSigError.Error())
-		return ErrAssertionSignature.WithInfo(invalidSigError.Error())
+	key, err := parsePublicKey(credentialBytes)
+	valid := false
+	switch key.(type) {
+	case OKPPublicKeyData:
+		o := key.(OKPPublicKeyData)
+		valid, err = o.verify(sigData, p.Response.Signature)
+	case EC2PublicKeyData:
+		e := key.(EC2PublicKeyData)
+		valid, err = e.verify(sigData, p.Response.Signature)
+	case RSAPublicKeyData:
+		r := key.(RSAPublicKeyData)
+		valid, err = r.verify(sigData, p.Response.Signature)
+	default:
+		return ErrUnsupportedKey
 	}
 
+	if true != valid {
+		return ErrAssertionSignature.WithInfo(err.Error())
+	}
 	return nil
 }

--- a/protocol/attestation_keystore.go
+++ b/protocol/attestation_keystore.go
@@ -44,7 +44,7 @@ func verifyAndroidKeystoreFormat(att AttestationObject, clientDataHash []byte) (
 	x5c, x509present := att.AttStatement["x5c"].([]interface{})
 	if x509present {
 		// Handle Basic Attestation steps for the x509 Certificate
-		return handleBasicAttestation(sig, clientDataHash, att.RawAuthData, att.AuthData.AAGUID, alg, x5c)
+		return handleBasicAttestation(sig, clientDataHash, att.RawAuthData, att.AuthData.AttData.AAGUID, alg, x5c)
 	}
 
 	// §8.4.2. Verify that sig is a valid signature over the concatenation of authenticatorData and clientDataHash

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -2,12 +2,9 @@ package protocol
 
 import (
 	"bytes"
-	"crypto/ecdsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"fmt"
-	"math/big"
 	"strings"
 )
 
@@ -54,7 +51,7 @@ func verifyPackedFormat(att AttestationObject, clientDataHash []byte) (string, [
 	x5c, x509present := att.AttStatement["x5c"].([]interface{})
 	if x509present {
 		// Handle Basic Attestation steps for the x509 Certificate
-		return handleBasicAttestation(sig, clientDataHash, att.RawAuthData, att.AuthData.AAGUID, alg, x5c)
+		return handleBasicAttestation(sig, clientDataHash, att.RawAuthData, att.AuthData.AttData.AAGUID, alg, x5c)
 	}
 
 	// Step 3. If ecdaaKeyId is present, then the attestation type is ECDAA.
@@ -66,7 +63,7 @@ func verifyPackedFormat(att AttestationObject, clientDataHash []byte) (string, [
 	}
 
 	// Step 4. If neither x5c nor ecdaaKeyId is present, self attestation is in use.
-	return handleSelfAttestation(alg, att.AuthData.PublicKey, att.RawAuthData, clientDataHash, sig)
+	return handleSelfAttestation(alg, att.AuthData.AttData.CredentialPublicKey, att.RawAuthData, clientDataHash, sig)
 }
 
 // Handle the attestation steps laid out in
@@ -188,40 +185,47 @@ func handleECDAAAttesation(signature, clientDataHash, ecdaaKeyID []byte) (string
 	return "Packed (ECDAA)", nil, ErrNotSpecImplemented
 }
 
-func handleSelfAttestation(alg int64, pubKey PublicKeyData, authData, clientDataHash, signature []byte) (string, []interface{}, error) {
-	fmt.Println("doing self packed")
+func handleSelfAttestation(alg int64, pubKey []byte, clientDataHash, authData, signature []byte) (string, []interface{}, error) {
 	attestationType := "Packed (Self)"
-	// §4.1 Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData.
-	if alg != pubKey.Algorithm {
-		return attestationType, nil, ErrInvalidAttestation.WithDetails("Public key algorithm does not equal att statement algorithm").WithInfo("Packed (Self)")
-	}
+	// Step 4.1 Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData.
 
-	// §4.2 Verify that sig is a valid signature over the concatenation of authenticatorData and
+	// Step 4.2 Verify that sig is a valid signature over the concatenation of authenticatorData and
 	// clientDataHash using the credential public key with alg.
+
 	verificationData := append(authData, clientDataHash...)
 
-	if COSEKeyType(pubKey.KeyType) == EllipticKey {
-		var asnSig struct {
-			R, S *big.Int
+	key, err := parsePublicKey(pubKey)
+	valid := false
+	switch key.(type) {
+	case OKPPublicKeyData:
+		o := key.(OKPPublicKeyData)
+		if alg != o.PublicKeyData.Algorithm {
+			return attestationType, nil, ErrInvalidAttestation.WithDetails("Public key algorithm does not equal att statement algorithm").WithInfo("Packed (Self)")
 		}
-		ecdsaKey := pubKey.KeyMaterial.(*ecdsa.PublicKey)
-		_, err := asn1.Unmarshal(signature, &asnSig)
-		if err != nil {
-			return attestationType, nil, ErrAttestation.WithDetails("Error unmarshalling signature for self attestation")
+		valid, err = o.verify(verificationData, signature)
+		if true != valid {
+			return attestationType, nil, ErrAttestation.WithDetails("Failed to validate signature with OKP key for self attestation").WithInfo(err.Error())
 		}
-		checkSum := sha256.Sum256(verificationData)
-		if ecdsa.Verify(ecdsaKey, checkSum[:], asnSig.R, asnSig.S) {
-			// §4.3 If successful, return implementation-specific values representing attestation type Self
-			// and an empty attestation trust path.
-			// we have nothing specific to return and don't need the empty trust path
-			return attestationType, nil, nil
-		} else {
-			return attestationType, nil, ErrAttestation.WithDetails("Error verifying the self-attested signature")
+	case EC2PublicKeyData:
+		e := key.(EC2PublicKeyData)
+		if alg != e.PublicKeyData.Algorithm {
+			return attestationType, nil, ErrInvalidAttestation.WithDetails("Public key algorithm does not equal att statement algorithm").WithInfo("Packed (Self)")
 		}
-	}
-
-	if COSEKeyType(pubKey.KeyType) == RSAKey {
-		return attestationType, nil, ErrNotImplemented.WithDetails("Self Attestation for RSA keys is unimplemented")
+		valid, err = e.verify(verificationData, signature)
+		if true != valid {
+			return attestationType, nil, ErrAttestation.WithDetails("Failed to validate signature with EC2 key for self attestation").WithInfo(err.Error())
+		}
+	case RSAPublicKeyData:
+		r := key.(RSAPublicKeyData)
+		if alg != r.PublicKeyData.Algorithm {
+			return attestationType, nil, ErrInvalidAttestation.WithDetails("Public key algorithm does not equal att statement algorithm").WithInfo("Packed (Self)")
+		}
+		valid, err = r.verify(verificationData, signature)
+		if true != valid {
+			return attestationType, nil, ErrAttestation.WithDetails("Failed to validate signature with RSA key for self attestation").WithInfo(err.Error())
+		}
+	default:
+		return "", nil, ErrUnsupportedKey
 	}
 
 	return attestationType, nil, nil

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -1,5 +1,18 @@
 package protocol
 
+import (
+	"bytes"
+	"crypto"
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"hash"
+	"math/big"
+
+	"github.com/google/go-tpm/tpm2"
+)
+
 var tpmAttestationKey = "tpm"
 
 func init() {
@@ -7,5 +20,346 @@ func init() {
 }
 
 func verifyTPMFormat(att AttestationObject, clientDataHash []byte) (string, []interface{}, error) {
-	return tpmAttestationKey, nil, ErrNotImplemented
+	// Given the verification procedure inputs attStmt, authenticatorData
+	// and clientDataHash, the verification procedure is as follows
+
+	// Verify that attStmt is valid CBOR conforming to the syntax defined
+	// above and perform CBOR decoding on it to extract the contained fields
+
+	ver, present := att.AttStatement["ver"].(string)
+	if !present {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Error retreiving ver value")
+	}
+
+	if ver != "2.0" {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("WebAuthn only supports TPM 2.0 currently")
+	}
+
+	alg, present := att.AttStatement["alg"].(int64)
+	if !present {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Error retreiving alg value")
+	}
+
+	coseAlg := COSEAlgorithmIdentifier(alg)
+
+	x5c, x509present := att.AttStatement["x5c"].([]interface{})
+	if !x509present {
+		// Handle Basic Attestation steps for the x509 Certificate
+		return tpmAttestationKey, nil, ErrNotImplemented
+	}
+
+	_, ecdaaKeyPresent := att.AttStatement["ecdaaKeyId"].([]byte)
+	if ecdaaKeyPresent {
+		return tpmAttestationKey, nil, ErrNotImplemented
+	}
+
+	sigBytes, present := att.AttStatement["sig"].([]byte)
+	if !present {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Error retreiving sig value")
+	}
+
+	certInfoBytes, present := att.AttStatement["certInfo"].([]byte)
+	if !present {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Error retreiving certInfo value")
+	}
+
+	pubAreaBytes, present := att.AttStatement["pubArea"].([]byte)
+	if !present {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Error retreiving pubArea value")
+	}
+
+	// Verify that the public key specified by the parameters and unique fields of pubArea
+	// is identical to the credentialPublicKey in the attestedCredentialData in authenticatorData.
+	pubArea, err := tpm2.DecodePublic(pubAreaBytes)
+	if err != nil {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Unable to decode TPMT_PUBLIC in attestation statement")
+	}
+
+	key, err := parsePublicKey(att.AuthData.AttData.CredentialPublicKey)
+	switch key.(type) {
+	case EC2PublicKeyData:
+		e := key.(EC2PublicKeyData)
+		if pubArea.ECCParameters.CurveID != tpm2.EllipticCurve(e.Curve) ||
+			pubArea.ECCParameters.Point.X != new(big.Int).SetBytes(e.XCoord) ||
+			pubArea.ECCParameters.Point.Y != new(big.Int).SetBytes(e.YCoord) {
+			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Mismatch between ECCParameters in pubArea and credentialPublicKey")
+		}
+	case RSAPublicKeyData:
+		r := key.(RSAPublicKeyData)
+		mod := new(big.Int).SetBytes(r.Modulus)
+		exp := uint32(r.Exponent[0]) + uint32(r.Exponent[1])<<8 + uint32(r.Exponent[2])<<16
+		if 0 != pubArea.RSAParameters.Modulus.Cmp(mod) ||
+			pubArea.RSAParameters.Exponent != exp {
+			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Mismatch between RSAParameters in pubArea and credentialPublicKey")
+		}
+	default:
+		return "", nil, ErrUnsupportedKey
+	}
+
+	// Concatenate authenticatorData and clientDataHash to form attToBeSigned
+	attToBeSigned := append(att.RawAuthData, clientDataHash...)
+
+	// Validate that certInfo is valid:
+	certInfo, err := tpm2.DecodeAttestationData(certInfoBytes)
+	// 1/4 Verify that magic is set to TPM_GENERATED_VALUE.
+	if certInfo.Magic != 0xff544347 {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Magic is not set to TPM_GENERATED_VALUE")
+	}
+	// 2/4 Verify that type is set to TPM_ST_ATTEST_CERTIFY.
+	if certInfo.Type != tpm2.TagAttestCertify {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Type is not set to TPM_ST_ATTEST_CERTIFY")
+	}
+	// 3/4 Verify that extraData is set to the hash of attToBeSigned using the hash algorithm employed in "alg".
+	f := HasherFromCOSEAlg(coseAlg)
+	h := f()
+	h.Write(attToBeSigned)
+	if 0 != bytes.Compare(certInfo.ExtraData, h.Sum(nil)) {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("ExtraData is not set to hash of attToBeSigned")
+	}
+	// 4/4 Verify that attested contains a TPMS_CERTIFY_INFO structure as specified in
+	// [TPMv2-Part2] section 10.12.3, whose name field contains a valid Name for pubArea,
+	// as computed using the algorithm in the nameAlg field of pubArea
+	// using the procedure specified in [TPMv2-Part1] section 16.
+	f, err = certInfo.AttestedCertifyInfo.Name.Digest.Alg.HashConstructor()
+	h = f()
+	h.Write(pubAreaBytes)
+	if 0 != bytes.Compare(h.Sum(nil), certInfo.AttestedCertifyInfo.Name.Digest.Value) {
+		return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Hash value mismatch attested and pubArea")
+	}
+
+	// Note that the remaining fields in the "Standard Attestation Structure"
+	// [TPMv2-Part1] section 31.2, i.e., qualifiedSigner, clockInfo and firmwareVersion
+	// are ignored. These fields MAY be used as an input to risk engines.
+
+	// If x5c is present, this indicates that the attestation type is not ECDAA.
+	if x509present {
+		// In this case:
+		// Verify the sig is a valid signature over certInfo using the attestation public key in aikCert with the algorithm specified in alg.
+		aikCertBytes, valid := x5c[0].([]byte)
+		if !valid {
+			return tpmAttestationKey, nil, ErrAttestation.WithDetails("Error getting certificate from x5c cert chain")
+		}
+
+		aikCert, err := x509.ParseCertificate(aikCertBytes)
+		if err != nil {
+			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Error parsing certificate from ASN.1")
+		}
+
+		sigAlg := SigAlgFromCOSEAlg(coseAlg)
+
+		err = aikCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), certInfoBytes, sigBytes)
+		if err != nil {
+			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", err))
+		}
+		// Verify that aikCert meets the requirements in §8.3.1 TPM Attestation Statement Certificate Requirements
+
+		// 1/6 Version MUST be set to 3.
+		if aikCert.Version != 3 {
+			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("AIK certificate version must be 3")
+		}
+		// 2/6 Subject field MUST be set to empty.
+		if aikCert.Subject.String() != "" {
+			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("AIK certificate subject must be empty")
+		}
+
+		// 3/6 The Subject Alternative Name extension MUST be set as defined in [TPMv2-EK-Profile] section 3.2.9{}
+
+		// TODO: figure out how to parse out the manufacturer/model/version from ASN.1 encoded format
+
+		//var tpmProps []string
+		//for _, ext := range aikCert.Extensions {
+		//	if ext.Id.Equal([]int{2, 5, 29, 17}) {
+		//		tpmProps, err = parseSANExtension(ext.Value)
+		//	}
+		//}
+
+		//if string(tpmProps[0]) != "foo" {
+		//	return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Invalid SAN data in AIK certificate")
+		//}
+
+		// 4/6 The Extended Key Usage extension MUST contain the "joint-iso-itu-t(2) internationalorganizations(23) 133 tcg-kp(8) tcg-kp-AIKCertificate(3)" OID.
+		//ekuFound := false
+		//for _, ext := range aikCert.Extensions {
+		//	if ext.Id.Equal([]int{2, 5, 29, 37}) {
+		//		ekuFound = true
+		//		var ekuVal asn1.ObjectIdentifier
+		//		asn1.Unmarshal(ext.Value, &ekuVal)
+		//		if !ekuVal.Equal(tcgKpAIKCertificate) {
+		//			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("AIK certificate EKU missing 2.23.133.8.3")
+		//		}
+		//	}
+		//}
+		//if false == ekuFound {
+		//	return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("AIK certificate missing EKU")
+		//}
+		// 5/6 The Basic Constraints extension MUST have the CA component set to false.
+		type basicConstraints struct {
+			IsCA        bool `asn1:"optional"`
+			MaxPathhLen int  `asn1:"optional,default:-1"`
+		}
+		var constraints basicConstraints
+		for _, ext := range aikCert.Extensions {
+			if ext.Id.Equal([]int{2, 5, 29, 19}) {
+				if rest, err := asn1.Unmarshal(ext.Value, &constraints); err != nil {
+					return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("AIK certificate basic constraints malformed")
+				} else if len(rest) != 0 {
+					return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("AIK certificate basic constraints contains extra data")
+				}
+			}
+		}
+		if constraints.IsCA != false {
+			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("AIK certificate basic constraints missing or CA is true")
+		}
+		// 6/6 An Authority Information Access (AIA) extension with entry id-ad-ocsp and a CRL Distribution Point extension [RFC5280] are both OPTIONAL as the status of many attestation certificates is available through metadata services. See, for example, the FIDO Metadata Service [FIDOMetadataService].
+	}
+
+	return tpmAttestationKey, x5c, err
+}
+
+func forEachSAN(extension []byte, callback func(tag int, data []byte) error) error {
+	// RFC 5280, 4.2.1.6
+
+	// SubjectAltName ::= GeneralNames
+	//
+	// GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+	//
+	// GeneralName ::= CHOICE {
+	//      otherName                       [0]     OtherName,
+	//      rfc822Name                      [1]     IA5String,
+	//      dNSName                         [2]     IA5String,
+	//      x400Address                     [3]     ORAddress,
+	//      directoryName                   [4]     Name,
+	//      ediPartyName                    [5]     EDIPartyName,
+	//      uniformResourceIdentifier       [6]     IA5String,
+	//      iPAddress                       [7]     OCTET STRING,
+	//      registeredID                    [8]     OBJECT IDENTIFIER }
+	var seq asn1.RawValue
+	rest, err := asn1.Unmarshal(extension, &seq)
+	if err != nil {
+		return err
+	} else if len(rest) != 0 {
+		return errors.New("x509: trailing data after X.509 extension")
+	}
+	if !seq.IsCompound || seq.Tag != 16 || seq.Class != 0 {
+		return asn1.StructuralError{Msg: "bad SAN sequence"}
+	}
+
+	rest = seq.Bytes
+	for len(rest) > 0 {
+		var v asn1.RawValue
+		rest, err = asn1.Unmarshal(rest, &v)
+		if err != nil {
+			return err
+		}
+
+		if err := callback(v.Tag, v.Bytes); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+const (
+	nameTypeDN = 4
+)
+
+var (
+	tcgKpAIKCertificate  = asn1.ObjectIdentifier{2, 23, 133, 2, 8}
+	tcgAtTpmManufacturer = asn1.ObjectIdentifier{2, 23, 133, 2, 1}
+	tcgAtTpmModel        = asn1.ObjectIdentifier{2, 23, 133, 2, 2}
+	tcgAtTpmVersion      = asn1.ObjectIdentifier{2, 23, 133, 2, 3}
+)
+
+type TPMManufacturerInfo struct {
+	Manufacturer TPMManufacturer
+	Model        TPMModel
+	Version      TPMVersion
+}
+
+type TPMManufacturer struct {
+	oid          asn1.ObjectIdentifier
+	manufacturer string
+}
+
+type TPMModel struct {
+	oid   asn1.ObjectIdentifier
+	model string
+}
+
+type TPMVersion struct {
+	oid     asn1.ObjectIdentifier
+	version string
+}
+
+func parseSANExtension(value []byte) (directoryNames []string, err error) {
+	err = forEachSAN(value, func(tag int, data []byte) error {
+		switch tag {
+		case nameTypeDN:
+			var subject TPMManufacturerInfo
+			asn1.Unmarshal(data, &subject)
+			directoryNames = append(directoryNames, string(data))
+		}
+		return nil
+	})
+	return
+}
+
+type SignatureAlgorithm int
+
+const (
+	UnknownSignatureAlgorithm SignatureAlgorithm = iota
+	MD2WithRSA
+	MD5WithRSA
+	SHA1WithRSA
+	SHA256WithRSA
+	SHA384WithRSA
+	SHA512WithRSA
+	DSAWithSHA1
+	DSAWithSHA256
+	ECDSAWithSHA1
+	ECDSAWithSHA256
+	ECDSAWithSHA384
+	ECDSAWithSHA512
+	SHA256WithRSAPSS
+	SHA384WithRSAPSS
+	SHA512WithRSAPSS
+)
+
+var signatureAlgorithmDetails = []struct {
+	algo    SignatureAlgorithm
+	coseAlg COSEAlgorithmIdentifier
+	name    string
+	hasher  func() hash.Hash
+}{
+	{SHA1WithRSA, AlgRS1, "SHA1-RSA", crypto.SHA1.New},
+	{SHA256WithRSA, AlgRS256, "SHA256-RSA", crypto.SHA256.New},
+	{SHA384WithRSA, AlgRS384, "SHA384-RSA", crypto.SHA384.New},
+	{SHA512WithRSA, AlgRS512, "SHA512-RSA", crypto.SHA512.New},
+	{SHA256WithRSAPSS, AlgPS256, "SHA256-RSAPSS", crypto.SHA256.New},
+	{SHA384WithRSAPSS, AlgPS384, "SHA384-RSAPSS", crypto.SHA384.New},
+	{SHA512WithRSAPSS, AlgPS512, "SHA512-RSAPSS", crypto.SHA512.New},
+	{ECDSAWithSHA256, AlgES256, "ECDSA-SHA256", crypto.SHA256.New},
+	{ECDSAWithSHA384, AlgES384, "ECDSA-SHA384", crypto.SHA384.New},
+	{ECDSAWithSHA512, AlgES512, "ECDSA-SHA512", crypto.SHA512.New},
+	{UnknownSignatureAlgorithm, AlgEdDSA, "EdDSA", crypto.SHA512.New},
+}
+
+func SigAlgFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) SignatureAlgorithm {
+	for _, details := range signatureAlgorithmDetails {
+		if details.coseAlg == coseAlg {
+			return details.algo
+		}
+	}
+	return UnknownSignatureAlgorithm
+}
+
+func HasherFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) func() hash.Hash {
+	for _, details := range signatureAlgorithmDetails {
+		if details.coseAlg == coseAlg {
+			return details.hasher
+		}
+	}
+	// default to SHA256?  Why not.
+	return crypto.SHA256.New
 }

--- a/protocol/attestation_u2f.go
+++ b/protocol/attestation_u2f.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
+
+	"github.com/ugorji/go/codec"
 )
 
 var u2fAttestationKey = "fido-u2f"
@@ -17,9 +19,9 @@ func init() {
 func verifyU2FFormat(att AttestationObject, clientDataHash []byte) (string, []interface{}, error) {
 	// Signing procedure step - If the credential public key of the given credential is not of
 	// algorithm -7 ("ES256"), stop and return an error.
-	if att.AuthData.PublicKey.Algorithm != -7 {
-		return u2fAttestationKey, nil, ErrUnsupportedAlgorithm.WithDetails("Non-ES256 Public Key algorithm used")
-	}
+	//if att.AuthData.PublicKey.Algorithm != -7 {
+	//	return u2fAttestationKey, nil, ErrUnsupportedAlgorithm.WithDetails("Non-ES256 Public Key algorithm used")
+	//}
 
 	// U2F Step 1. Verify that attStmt is valid CBOR conforming to the syntax defined above
 	// and perform CBOR decoding on it to extract the contained fields.
@@ -80,9 +82,9 @@ func verifyU2FFormat(att AttestationObject, clientDataHash []byte) (string, []in
 
 	rpIdHash := att.AuthData.RPIDHash
 
-	credentialID := att.AuthData.CredentialID
+	credentialID := att.AuthData.AttData.CredentialID
 
-	credentialPublicKey := att.AuthData.PublicKey
+	credentialPublicKey := att.AuthData.AttData.CredentialPublicKey
 
 	// Step 4. Convert the COSE_KEY formatted credentialPublicKey (see Section 7 of RFC8152 [https://www.w3.org/TR/webauthn/#biblio-rfc8152])
 	// to Raw ANSI X9.62 public key format (see ALG_KEY_ECC_X962_RAW in Section 3.6.2 Public Key
@@ -96,15 +98,17 @@ func verifyU2FFormat(att AttestationObject, clientDataHash []byte) (string, []in
 	// its size to be of 32 bytes. If size differs or "-3" key is not found, terminate this algorithm and
 	// return an appropriate error.
 
-	if len(credentialPublicKey.XCoord) > 32 || len(credentialPublicKey.YCoord) > 32 {
-		return u2fAttestationKey, nil, ErrAttestation.WithDetails("X or Y Coordinate for key is invalid length")
-	}
+	//if len(credentialPublicKey.XCoord) > 32 || len(credentialPublicKey.YCoord) > 32 {
+	//	return u2fAttestationKey, nil, ErrAttestation.WithDetails("X or Y Coordinate for key is invalid length")
+	//}
+
+	key := EC2PublicKeyData{}
+	codec.NewDecoder(bytes.NewReader(credentialPublicKey), new(codec.CborHandle)).Decode(&key)
 
 	// Let publicKeyU2F be the concatenation 0x04 || x || y.
-
 	publicKeyU2F := bytes.NewBuffer([]byte{0x04})
-	publicKeyU2F.Write(credentialPublicKey.XCoord)
-	publicKeyU2F.Write(credentialPublicKey.YCoord)
+	publicKeyU2F.Write(key.XCoord)
+	publicKeyU2F.Write(key.YCoord)
 
 	// Step 5. Let verificationData be the concatenation of (0x00 || rpIdHash || clientDataHash || credentialId || publicKeyU2F)
 	// (see §4.3 of FIDO-U2F-Message-Formats [https://www.w3.org/TR/webauthn/#biblio-fido-u2f-message-formats]).
@@ -122,5 +126,5 @@ func verifyU2FFormat(att AttestationObject, clientDataHash []byte) (string, []in
 	}
 
 	// Step 7. If successful, return attestation type Basic with the attestation trust path set to x5c.
-	return "Fido U2F Basic", x5c, nil
+	return "Fido U2F Basic", x5c, sigErr
 }

--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -1,9 +1,6 @@
 package webauthn
 
 import (
-	"crypto/x509"
-	"encoding/pem"
-
 	"github.com/duo-labs/webauthn/protocol"
 )
 
@@ -20,23 +17,12 @@ type Credential struct {
 }
 
 func MakeNewCredential(c *protocol.ParsedCredentialCreationData) (*Credential, error) {
-	keyMaterial := c.Response.AttestationObject.AuthData.PublicKey.KeyMaterial
-	newPublicKeyDER, err := x509.MarshalPKIXPublicKey(keyMaterial)
-
-	if err != nil {
-		return nil, err
-	}
-
-	publicKeyPEM := &pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: newPublicKeyDER,
-	}
 
 	newCredential := &Credential{
-		ID:        c.Response.AttestationObject.AuthData.CredentialID,
-		PublicKey: pem.EncodeToMemory(publicKeyPEM),
+		ID:        c.Response.AttestationObject.AuthData.AttData.CredentialID,
+		PublicKey: c.Response.AttestationObject.AuthData.AttData.CredentialPublicKey,
 		Authenticator: Authenticator{
-			AAGUID:    c.Response.AttestationObject.AuthData.AAGUID,
+			AAGUID:    c.Response.AttestationObject.AuthData.AttData.AAGUID,
 			SignCount: c.Response.AttestationObject.AuthData.Counter,
 		},
 	}

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -13,7 +13,6 @@ import (
 
 type RegistrationOption func(*protocol.PublicKeyCredentialCreationOptions)
 
-// Generate a new set of registration data to be sent to the client and authenticator.
 func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOption) (*protocol.CredentialCreation, *SessionData, error) {
 	challenge, err := protocol.CreateChallenge()
 	if err != nil {
@@ -41,6 +40,46 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 		protocol.CredentialParameter{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: protocol.AlgES256,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgES384,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgES512,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgRS1,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgRS256,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgRS384,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgRS512,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgPS256,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgPS384,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgPS512,
+		},
+		protocol.CredentialParameter{
+			Type:      protocol.PublicKeyCredentialType,
+			Algorithm: protocol.AlgEdDSA,
 		},
 	}
 
@@ -77,29 +116,24 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 	return &response, &newSessionData, nil
 }
 
-// Provide non-default parameters regarding the authenticator to select.
 func WithAuthenticatorSelection(authenticatorSelection protocol.AuthenticatorSelection) RegistrationOption {
 	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
 		cco.AuthenticatorSelection = authenticatorSelection
 	}
 }
 
-// Provide non-default parameters regarding credentials to exclude from retrieval.
 func WithExclusions(excludeList []protocol.CredentialDescriptor) RegistrationOption {
 	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
 		cco.CredentialExcludeList = excludeList
 	}
 }
 
-// Provide non-default parameters regarding whether the authenticator should attest to the credential.
 func WithConveyancePreference(preference protocol.ConveyancePreference) RegistrationOption {
 	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
 		cco.Attestation = preference
 	}
 }
 
-// Take the response from the authenticator and client and verify the credential against the user's credentials and
-// session data.
 func (webauthn *WebAuthn) FinishRegistration(user User, session SessionData, response *http.Request) (*Credential, error) {
 	if !bytes.Equal(user.WebAuthnID(), session.UserID) {
 		protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")


### PR DESCRIPTION
Change from storing parsed credentialPublicKey to storing raw key, decode when needed.  Adds support for things like Windows Hello, extensions data, as well as alternate algorithms and key types.