### PR TITLE
protocol: fix FlagUserVerified value

### DIFF
--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -105,15 +105,19 @@ type AuthenticatorFlags byte
 // The bits that do not have flags are reserved for future use.
 const (
 	// FlagUserPresent Bit 00000001 in the byte sequence. Tells us if user is present
-	FlagUserPresent = 0x001 // Referred to as UP
+	FlagUserPresent AuthenticatorFlags = 1 << iota // Referred to as UP
+	_                                              // Reserved
 	// FlagUserVerified Bit 00000100 in the byte sequence. Tells us if user is verified
 	// by the authenticator using a biometric or PIN
-	FlagUserVerified = 0x003 // Referred to as UV
+	FlagUserVerified // Referred to as UV
+	_                // Reserved
+	_                // Reserved
+	_                // Reserved
 	// FlagAttestedCredentialData Bit 01000000 in the byte sequence. Indicates whether
 	// the authenticator added attested credential data.
-	FlagAttestedCredentialData = 0x040 // Referred to as AT
-	// FlagHasExtension Bite 10000000 in the byte sequence. Indicates if the authenticator data has extensions.
-	FlagHasExtensions = 0x080 //  Referred to as ED
+	FlagAttestedCredentialData // Referred to as AT
+	// FlagHasExtension Bit 10000000 in the byte sequence. Indicates if the authenticator data has extensions.
+	FlagHasExtensions //  Referred to as ED
 )
 
 // UserPresent returns if the UP flag was set

--- a/protocol/authenticator_test.go
+++ b/protocol/authenticator_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestAuthenticatorFlags_UserPresent(t *testing.T) {
-	var goodByte byte = 0x001
-	var badByte byte = 0x010
+	var goodByte byte = 0x01
+	var badByte byte = 0x10
 	tests := []struct {
 		name string
 		flag AuthenticatorFlags
@@ -35,8 +35,8 @@ func TestAuthenticatorFlags_UserPresent(t *testing.T) {
 }
 
 func TestAuthenticatorFlags_UserVerified(t *testing.T) {
-	var goodByte byte = 0x003
-	var badByte byte = 0x020
+	var goodByte byte = 0x04
+	var badByte byte = 0x02
 	tests := []struct {
 		name string
 		flag AuthenticatorFlags
@@ -63,8 +63,8 @@ func TestAuthenticatorFlags_UserVerified(t *testing.T) {
 }
 
 func TestAuthenticatorFlags_HasAttestedCredentialData(t *testing.T) {
-	var goodByte byte = 0x040
-	var badByte byte = 0x010
+	var goodByte byte = 0x40
+	var badByte byte = 0x01
 	tests := []struct {
 		name string
 		flag AuthenticatorFlags
@@ -91,8 +91,8 @@ func TestAuthenticatorFlags_HasAttestedCredentialData(t *testing.T) {
 }
 
 func TestAuthenticatorFlags_HasExtensions(t *testing.T) {
-	var goodByte byte = 0x080
-	var badByte byte = 0x010
+	var goodByte byte = 0x80
+	var badByte byte = 0x01
 	tests := []struct {
 		name string
 		flag AuthenticatorFlags


### PR DESCRIPTION
The flag was 0x030 (0b00000011) but should be 0x04 (0b00000100).

https://www.w3.org/TR/webauthn/#sec-authenticator-data

I changed the constants definition to use iota to avoid any other mistakes and changed the tests to use conventional 2-digit hexadecimal notation for byte values.