### PR TITLE
Fix session mismatch error handling

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -84,7 +84,7 @@ func WithUserVerification(userVerfication protocol.UserVerificationRequirement) 
 // Take the response from the client and validate it against the user credentials and stored session data
 func (webauthn *WebAuthn) FinishLogin(user User, session SessionData, response *http.Request) (*Credential, error) {
 	if !bytes.Equal(user.WebAuthnID(), session.UserID) {
-		protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
+		return nil, protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
 	}
 
 	parsedResponse, err := protocol.ParseCredentialRequestResponse(response)

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -1,0 +1,25 @@
+package webauthn
+
+import (
+	"testing"
+
+	"github.com/duo-labs/webauthn/protocol"
+)
+
+func TestLogin_FinishLoginFailure(t *testing.T) {
+	user := &defaultUser{
+		id: []byte("123"),
+	}
+	session := SessionData{
+		UserID: []byte("ABC"),
+	}
+
+	webauthn := &WebAuthn{}
+	credential, err := webauthn.FinishLogin(user, session, nil)
+	if err == nil {
+		t.Errorf("FinishLogin() error = nil, want %v", protocol.ErrBadRequest.Type)
+	}
+	if credential != nil {
+		t.Errorf("FinishLogin() credential = %v, want nil", credential)
+	}
+}

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -105,7 +105,7 @@ func WithExtensions(preference protocol.AuthenticationExtensions) RegistrationOp
 // session data.
 func (webauthn *WebAuthn) FinishRegistration(user User, session SessionData, response *http.Request) (*Credential, error) {
 	if !bytes.Equal(user.WebAuthnID(), session.UserID) {
-		protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
+		return nil, protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
 	}
 
 	parsedResponse, err := protocol.ParseCredentialCreationResponse(response)

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -2,9 +2,25 @@ package webauthn
 
 import (
 	"testing"
+
+	"github.com/duo-labs/webauthn/protocol"
 )
 
 
-func TestRegistration(t *testing.T) {
+func TestRegistration_FinishRegistrationFailure(t *testing.T) {
+	user := &defaultUser{
+		id: []byte("123"),
+	}
+	session := SessionData{
+		UserID: []byte("ABC"),
+	}
 
+	webauthn := &WebAuthn{}
+	credential, err := webauthn.FinishRegistration(user, session, nil)
+	if err == nil {
+		t.Errorf("FinishRegistration() error = nil, want %v", protocol.ErrBadRequest.Type)
+	}
+	if credential != nil {
+		t.Errorf("FinishRegistration() credential = %v, want nil", credential)
+	}
 }


### PR DESCRIPTION
Error message is not being returned for the final steps in login/registration in the case of session mismatch