### PR TITLE
Remove dafult AuthenticatorAttachment

### DIFF
--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -43,9 +43,8 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 
 	rrk := false
 	authSelection := protocol.AuthenticatorSelection{
-		AuthenticatorAttachment: protocol.CrossPlatform,
-		RequireResidentKey:      &rrk,
-		UserVerification:        protocol.VerificationPreferred,
+		RequireResidentKey: &rrk,
+		UserVerification:   protocol.VerificationPreferred,
 	}
 
 	creationOptions := protocol.PublicKeyCredentialCreationOptions{


### PR DESCRIPTION
Ideally there would be no default AuthenticatorAttachment preference so the user can choose to use a platform or roaming authenticator (currently have to override by supplying opts to `BeginRegistration()`)