### PR TITLE
Increase flexibility of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ func FinishRegistration(w http.ResponseWriter, r *http.Request) {
     // Get the session data stored from the function above
     // using gorilla/sessions it could look like this
     sessionData := store.Get(r, "registration-session")
-    credential, err := web.FinishRegistration(&user, sessionData, r)
+    parsedResponse, err := protocol.ParseCredentialCreationResponseBody(r.Body)
+    credential, err := web.CreateCredential(&user, sessionData, parsedResponse)
     // Handle validation or input errors
     // If creation was successful, store the credential object
     JSONResponse(w, "Registration Success", http.StatusOK) // Handle next steps
@@ -84,7 +85,8 @@ func FinishLogin(w http.ResponseWriter, r *http.Request) {
     // Get the session data stored from the function above
     // using gorilla/sessions it could look like this
     sessionData := store.Get(r, "login-session")
-    credential, err := webauthn.FinishLogin(&user, sessionData, r)
+    parsedResponse, err := protocol.ParseCredentialRequestResponseBody(r.Body)
+    credential, err := webauthn.ValidateLogin(&user, sessionData, parsedResponse)
     // Handle validation or input errors
     // If login was successful, handle next steps
     JSONResponse(w, "Login Success", http.StatusOK)

--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/duo-labs/webauthn/protocol/webauthncose"
@@ -47,8 +48,19 @@ type ParsedAssertionResponse struct {
 // the attestation response data in a raw, mostly base64 encoded format, and parses the data into
 // manageable structures
 func ParseCredentialRequestResponse(response *http.Request) (*ParsedCredentialAssertionData, error) {
+	if response == nil || response.Body == nil {
+		return nil, ErrBadRequest.WithDetails("No response given")
+	}
+	return ParseCredentialRequestResponseBody(response.Body)
+}
+
+// Parse the credential request response into a format that is either required by the specification
+// or makes the assertion verification steps easier to complete. This takes an io.Reader that contains
+// the attestation response data in a raw, mostly base64 encoded format, and parses the data into
+// manageable structures
+func ParseCredentialRequestResponseBody(body io.Reader) (*ParsedCredentialAssertionData, error) {
 	var car CredentialAssertionResponse
-	err := json.NewDecoder(response.Body).Decode(&car)
+	err := json.NewDecoder(body).Decode(&car)
 	if err != nil {
 		return nil, ErrBadRequest.WithDetails("Parse error for Assertion")
 	}

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 )
 
@@ -53,8 +54,15 @@ type ParsedCredentialCreationData struct {
 }
 
 func ParseCredentialCreationResponse(response *http.Request) (*ParsedCredentialCreationData, error) {
+	if response == nil || response.Body == nil {
+		return nil, ErrBadRequest.WithDetails("No response given")
+	}
+	return ParseCredentialCreationResponseBody(response.Body)
+}
+
+func ParseCredentialCreationResponseBody(body io.Reader) (*ParsedCredentialCreationData, error) {
 	var ccr CredentialCreationResponse
-	err := json.NewDecoder(response.Body).Decode(&ccr)
+	err := json.NewDecoder(body).Decode(&ccr)
 	if err != nil {
 		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo(err.Error())
 	}

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -91,14 +91,19 @@ func WithAssertionExtensions(extensions protocol.AuthenticationExtensions) Login
 
 // Take the response from the client and validate it against the user credentials and stored session data
 func (webauthn *WebAuthn) FinishLogin(user User, session SessionData, response *http.Request) (*Credential, error) {
-	if !bytes.Equal(user.WebAuthnID(), session.UserID) {
-		return nil, protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
-	}
-
 	parsedResponse, err := protocol.ParseCredentialRequestResponse(response)
 	if err != nil {
 		fmt.Println(err)
 		return nil, err
+	}
+
+	return webauthn.ValidateLogin(user, session, parsedResponse)
+}
+
+// ValidateLogin takes a parsed response and validates it against the user credentials and session data
+func (webauthn *WebAuthn) ValidateLogin(user User, session SessionData, parsedResponse *protocol.ParsedCredentialAssertionData) (*Credential, error) {
+	if !bytes.Equal(user.WebAuthnID(), session.UserID) {
+		return nil, protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
 	}
 
 	// Step 1. If the allowCredentials option was given when this authentication ceremony was initiated,

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -105,13 +105,18 @@ func WithExtensions(extension protocol.AuthenticationExtensions) RegistrationOpt
 // Take the response from the authenticator and client and verify the credential against the user's credentials and
 // session data.
 func (webauthn *WebAuthn) FinishRegistration(user User, session SessionData, response *http.Request) (*Credential, error) {
-	if !bytes.Equal(user.WebAuthnID(), session.UserID) {
-		return nil, protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
-	}
-
 	parsedResponse, err := protocol.ParseCredentialCreationResponse(response)
 	if err != nil {
 		return nil, err
+	}
+
+	return webauthn.CreateCredential(user, session, parsedResponse)
+}
+
+// CreateCredential verifies a parsed response against the user's credentials and session data.
+func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parsedResponse *protocol.ParsedCredentialCreationData) (*Credential, error) {
+	if !bytes.Equal(user.WebAuthnID(), session.UserID) {
+		return nil, protocol.ErrBadRequest.WithDetails("ID mismatch for User and Session")
 	}
 
 	shouldVerifyUser := webauthn.Config.AuthenticatorSelection.UserVerification == protocol.VerificationRequired


### PR DESCRIPTION
In order to allow for greater flexibility in the `webauthn` package I
added the `CreateCredential` and `ValidateLogin` methods. Instead of
accepting a `http.Request` they now take a parsed response, so the
source can be up to the consumer of the package.

Aside from that I added two new methods in the `protocol` package:
`ParseCredentialRequestResponseBody` and
`ParseCredentialCreationResponseBody`. Instead of taking a
`http.Request` these methods accept a `io.Reader`.

The changes have been made with backwards compatibility in mind.