### PR TITLE
Removed unneeded fmt.Print* lines. Fixes #55

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -98,7 +98,6 @@ func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPa
 	// returned by the authenticator
 	validError := p.Response.CollectedClientData.Verify(storedChallenge, AssertCeremony, relyingPartyOrigin)
 	if validError != nil {
-		fmt.Println("got error, ", validError)
 		return validError
 	}
 

--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -82,8 +82,7 @@ func (ccr *AuthenticatorAttestationResponse) Parse() (*ParsedAttestationResponse
 
 	err := json.Unmarshal(ccr.ClientDataJSON, &p.CollectedClientData)
 	if err != nil {
-		fmt.Println("attestation response parsing error")
-		return nil, err
+		return nil, ErrParsingData.WithInfo(err.Error())
 	}
 
 	cborHandler := codec.CborHandle{}
@@ -91,8 +90,7 @@ func (ccr *AuthenticatorAttestationResponse) Parse() (*ParsedAttestationResponse
 	// Decode the attestation data with unmarshalled auth data
 	err = codec.NewDecoderBytes(ccr.AttestationObject, &cborHandler).Decode(&p.AttestationObject)
 	if err != nil {
-		fmt.Println("parsing error")
-		return nil, err
+		return nil, ErrParsingData.WithInfo(err.Error())
 	}
 
 	// Step 8. Perform CBOR decoding on the attestationObject field of the AuthenticatorAttestationResponse
@@ -100,8 +98,7 @@ func (ccr *AuthenticatorAttestationResponse) Parse() (*ParsedAttestationResponse
 	// the attestation statement attStmt.
 	err = p.AttestationObject.AuthData.Unmarshal(p.AttestationObject.RawAuthData)
 	if err != nil {
-		fmt.Println("error decoding auth data")
-		return nil, err
+		return nil, fmt.Errorf("error decoding auth data: %v", err)
 	}
 
 	if !p.AttestationObject.AuthData.Flags.HasAttestedCredentialData() {

--- a/protocol/attestation_safetynet.go
+++ b/protocol/attestation_safetynet.go
@@ -87,7 +87,6 @@ func verifySafetyNetFormat(att AttestationObject, clientDataHash []byte) (string
 	var safetyNetResponse SafetyNetResponse
 	err = mapstructure.Decode(token.Claims, &safetyNetResponse)
 	if err != nil {
-		fmt.Println(err)
 		return safetyNetAttestationKey, nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Error parsing the SafetyNet response: %+v", err))
 	}
 
@@ -133,7 +132,6 @@ func verifySafetyNetFormat(att AttestationObject, clientDataHash []byte) (string
 		// allow old timestamp for testing purposes
 		// TODO: Make this user configurable
 		msg := "SafetyNet response with timestamp before one minute ago"
-		fmt.Println(msg)
 		if metadata.Conformance {
 			return "Basic attestation with SafetyNet", nil, ErrInvalidAttestation.WithDetails(msg)
 		}

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -74,7 +74,6 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	challenge := c.Challenge
 	if 0 != strings.Compare(storedChallenge, challenge) {
 		err := ErrVerification.WithDetails("Error validating challenge")
-		fmt.Printf("\nExpected b Value: %s\nReceived b: %s\n", storedChallenge, challenge)
 		return err.WithInfo(fmt.Sprintf("Expected b Value: %#v\nReceived b: %#v\n", storedChallenge, challenge))
 	}
 
@@ -86,7 +85,6 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	}
 
 	if !strings.EqualFold(clientDataOrigin.Hostname(), relyingPartyOrigin) {
-		fmt.Printf("Expected: %q\nReceived: %q\n", relyingPartyOrigin, clientDataOrigin.Hostname())
 		err := ErrVerification.WithDetails("Error validating origin")
 		return err.WithInfo(fmt.Sprintf("Expected Value: %s\n Received: %s\n", relyingPartyOrigin, clientDataOrigin.Hostname()))
 	}

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -282,7 +282,6 @@ func DisplayPublicKey(cpk []byte) string {
 			X:     big.NewInt(0).SetBytes(pKey.XCoord),
 			Y:     big.NewInt(0).SetBytes(pKey.YCoord),
 		}
-		fmt.Printf("Got formatted key %+v\n", eKey)
 		data, err := x509.MarshalPKIXPublicKey(eKey)
 		if err != nil {
 			return "Cannot display key"

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -3,7 +3,6 @@ package webauthn
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"net/http"
 
 	"github.com/duo-labs/webauthn/protocol"
@@ -97,7 +96,6 @@ func (webauthn *WebAuthn) FinishLogin(user User, session SessionData, response *
 
 	parsedResponse, err := protocol.ParseCredentialRequestResponse(response)
 	if err != nil {
-		fmt.Println(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR fixes #55 by removing various unnecessary calls to `fmt.Print*`. Since we're used as a library, we should return errors to the caller, rather than printing them ourselves.

In most cases, I was able to simply remove the print statements since we return the error immediately afterwards. However, there are some cases where I tried to update the errors we return to be more descriptive, e.g. `err` -> `ErrParsingData.WithInfo(err.Error())`.

If you could please review that the error types I used in these cases are appropriate, I'd appreciate it!