### PR TITLE
change origin verify to use fully qualified origin per spec

### DIFF
--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -32,7 +32,7 @@ func TestAttestationVerify(t *testing.T) {
 			// Test Base Verification
 			err = pcc.Verify(options.Response.Challenge.String(), false, options.Response.RelyingParty.ID, options.Response.RelyingParty.Name)
 			if err != nil {
-				t.Fatalf("Not valid: %+v", err)
+				t.Fatalf("Not valid: %+v (%+s)", err, err.(*Error).DevInfo)
 			}
 		})
 	}
@@ -85,7 +85,7 @@ var testAttestationOptions = []string{
 	`{"publicKey": {
 		"challenge": "rWiex8xDOPfiCgyFu4BLW6vVOmXKgPwHrlMCgEs9SBA=",
 		"rp": {
-		"name": "localhost",
+		"name": "http://localhost:9005",
 		"id": "localhost"
 		},
 		"user": {
@@ -110,7 +110,7 @@ var testAttestationOptions = []string{
 	`{"publicKey": {
 		"challenge": "+Ri5NZTzJ8b6mvW3TVScLotEoALfgBa2Bn4YSaIObHc=",
 		"rp": {
-		"name": "webauthn.io",
+		"name": "https://webauthn.io",
 		"id": "webauthn.io"
 		},
 		"user": {
@@ -136,7 +136,7 @@ var testAttestationOptions = []string{
 		"publicKey": {
 		  "challenge": "sVt4ScceMzqFSnfAq8hgLzblvo3fa4/aFVEcIESHIJ0=",
 		  "rp": {
-			"name": "webauthn.io",
+			"name": "https://webauthn.io",
 			"id": "webauthn.io"
 		  },
 		  "user": {

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -49,6 +49,11 @@ const (
 	NotSupported TokenBindingStatus = "not-supported"
 )
 
+// Returns the origin per the HTML spec: (scheme)://(host)[:(port)]
+func FullyQualifiedOrigin(u *url.URL) string {
+	return fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+}
+
 // Handles steps 3 through 6 of verfying the registering client data of a
 // new credential and steps 7 through 10 of verifying an authentication assertion
 // See https://www.w3.org/TR/webauthn/#registering-a-new-credential
@@ -84,9 +89,9 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 		return ErrParsingData.WithDetails("Error decoding clientData origin as URL")
 	}
 
-	if !strings.EqualFold(clientDataOrigin.Hostname(), relyingPartyOrigin) {
+	if !strings.EqualFold(FullyQualifiedOrigin(clientDataOrigin), relyingPartyOrigin) {
 		err := ErrVerification.WithDetails("Error validating origin")
-		return err.WithInfo(fmt.Sprintf("Expected Value: %s\n Received: %s\n", relyingPartyOrigin, clientDataOrigin.Hostname()))
+		return err.WithInfo(fmt.Sprintf("Expected Value: %s\n Received: %s\n", relyingPartyOrigin, FullyQualifiedOrigin(clientDataOrigin)))
 	}
 
 	// Registration Step 6 and Assertion Step 10. Verify that the value of C.tokenBinding.status

--- a/protocol/client_test.go
+++ b/protocol/client_test.go
@@ -15,6 +15,7 @@ func setupCollectedClientData(challenge []byte) *CollectedClientData {
 	ccd.Challenge = base64.RawURLEncoding.EncodeToString(challenge)
 	return ccd
 }
+
 func TestVerifyCollectedClientData(t *testing.T) {
 	newChallenge, err := CreateChallenge()
 	if err != nil {
@@ -25,7 +26,7 @@ func TestVerifyCollectedClientData(t *testing.T) {
 	var storedChallenge = newChallenge
 
 	originURL, _ := url.Parse(ccd.Origin)
-	err = ccd.Verify(storedChallenge.String(), ccd.Type, originURL.Hostname())
+	err = ccd.Verify(storedChallenge.String(), ccd.Type, FullyQualifiedOrigin(originURL))
 	if err != nil {
 		t.Fatalf("error verifying challenge: expected %#v got %#v", Challenge(ccd.Challenge), storedChallenge)
 	}

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -214,7 +214,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				storedChallenge:    byteChallenge,
 				verifyUser:         false,
 				relyingPartyID:     `webauthn.io`,
-				relyingPartyOrigin: `webauthn.io`,
+				relyingPartyOrigin: `https://webauthn.io`,
 			},
 			wantErr: false,
 		},

--- a/webauthn/main.go
+++ b/webauthn/main.go
@@ -50,11 +50,11 @@ func (config *Config) validate() error {
 	if config.RPOrigin == "" {
 		config.RPOrigin = config.RPID
 	} else {
-		url, err := url.Parse(config.RPOrigin)
+		u, err := url.Parse(config.RPOrigin)
 		if err != nil {
 			return fmt.Errorf("RPOrigin not valid URL: %+v", err)
 		}
-		config.RPOrigin = url.Hostname()
+		config.RPOrigin = protocol.FullyQualifiedOrigin(u)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #59.

Changes the origin verify step to use the fully qualified origin as specified in the final WebAuthn Level 1 spec. Per referenced RFC6454, this is the tuple of scheme, host, and port. `url.Host` returns both host and port, if port is present in the URL. 

Note that RFC6454 does specify that the port will be present and inferred from the scheme if it is not provided in the URI; in reality, however, client implementations behave as expected and leave the port off of the origin if the default port is used.