### PR TITLE
fixed crash when providing a nil signature to EC2PublicKeyData.Verify

### DIFF
--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -92,8 +92,11 @@ func (k *EC2PublicKeyData) Verify(data []byte, sig []byte) (bool, error) {
 	f := HasherFromCOSEAlg(COSEAlgorithmIdentifier(k.PublicKeyData.Algorithm))
 	h := f()
 	h.Write(data)
-	_, error := asn1.Unmarshal(sig, e)
-	return ecdsa.Verify(pubkey, h.Sum(nil), e.R, e.S), error
+	_, err := asn1.Unmarshal(sig, e)
+	if err != nil {
+		return false, ErrSigNotProvidedOrInvalid
+	}
+	return ecdsa.Verify(pubkey, h.Sum(nil), e.R, e.S), nil
 }
 
 // Verify RSA Public Key Signature
@@ -368,6 +371,10 @@ var (
 	ErrUnsupportedAlgorithm = &Error{
 		Type:    "unsupported_key_algorithm",
 		Details: "Unsupported public key algorithm",
+	}
+	ErrSigNotProvidedOrInvalid = &Error{
+		Type: "signature_not_provided_or_invalid",
+		Details: "Signature invalid or not provided",
 	}
 )
 


### PR DESCRIPTION
when sending an invalid `CredentialAssertionData` (FinishLogin), the error is not handled correctly leading to a nil ptr dereference.