### PR TITLE
swap session allowed credentials against user credentials validation loops

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -113,8 +113,8 @@ func (webauthn *WebAuthn) ValidateLogin(user User, session SessionData, parsedRe
 	var credentialFound bool
 	if len(session.AllowedCredentialIDs) > 0 {
 		var credentialsOwned bool
-		for _, userCredential := range userCredentials {
-			for _, allowedCredentialID := range session.AllowedCredentialIDs {
+		for _, allowedCredentialID := range session.AllowedCredentialIDs {
+			for _, userCredential := range userCredentials {
 				if bytes.Equal(userCredential.ID, allowedCredentialID) {
 					credentialsOwned = true
 					break


### PR DESCRIPTION
When validating the list of allowed credential IDs of a login session against the list of available user credential IDs, the loop should start from the session's allowed credential IDs; otherwise there's the risk that a possible user credential that does not exist in the session, overwrites the correct `true` value of `credentialsOwned`, in case it happens to come after the valid credentials in the iteration.