### PR TITLE
Use CTAP2 canonical CBOR encoding form

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,13 +2,14 @@ github.com/cloudflare/cfssl v0.0.0-20190726000631-633726f6bcb7 h1:Puu1hUwfps3+1C
 github.com/cloudflare/cfssl v0.0.0-20190726000631-633726f6bcb7/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
 github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
 github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/google/certificate-transparency-go v1.0.21 h1:Yf1aXowfZ2nuboBsg7iYGLmwsOARdV86pfH3g95wXmE=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -23,4 +24,5 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -3,12 +3,11 @@ package protocol
 import (
 	"bytes"
 	"encoding/base64"
+	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
-
-	"github.com/fxamacker/cbor/v2"
 )
 
 func TestParseCredentialRequestResponse(t *testing.T) {
@@ -124,10 +123,10 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 					// Unmarshall CredentialPublicKey
 					var pkWant interface{}
 					keyBytesWant := tt.want.Response.AuthenticatorData.AttData.CredentialPublicKey
-					cbor.Unmarshal(keyBytesWant, &pkWant)
+					webauthncbor.Unmarshal(keyBytesWant, &pkWant)
 					var pkGot interface{}
 					keyBytesGot := got.Response.AuthenticatorData.AttData.CredentialPublicKey
-					cbor.Unmarshal(keyBytesGot, &pkGot)
+					webauthncbor.Unmarshal(keyBytesGot, &pkGot)
 					if !reflect.DeepEqual(pkGot, pkWant) {
 						t.Errorf("Response = %+v \n want: %+v", pkGot, pkWant)
 					} else {

--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -4,8 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-
-	"github.com/fxamacker/cbor/v2"
+	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 )
 
 // From §5.2.1 (https://www.w3.org/TR/webauthn/#authenticatorattestationresponse)
@@ -85,7 +84,7 @@ func (ccr *AuthenticatorAttestationResponse) Parse() (*ParsedAttestationResponse
 		return nil, ErrParsingData.WithInfo(err.Error())
 	}
 
-	err = cbor.Unmarshal(ccr.AttestationObject, &p.AttestationObject)
+	err = webauthncbor.Unmarshal(ccr.AttestationObject, &p.AttestationObject)
 	if err != nil {
 		return nil, ErrParsingData.WithInfo(err.Error())
 	}

--- a/protocol/attestation_u2f.go
+++ b/protocol/attestation_u2f.go
@@ -5,9 +5,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
+	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 
 	"github.com/duo-labs/webauthn/protocol/webauthncose"
-	"github.com/fxamacker/cbor/v2"
 )
 
 var u2fAttestationKey = "fido-u2f"
@@ -25,7 +25,7 @@ func verifyU2FFormat(att AttestationObject, clientDataHash []byte) (string, []in
 	// Signing procedure step - If the credential public key of the given credential is not of
 	// algorithm -7 ("ES256"), stop and return an error.
 	key := webauthncose.EC2PublicKeyData{}
-	cbor.Unmarshal(att.AuthData.AttData.CredentialPublicKey, &key)
+	webauthncbor.Unmarshal(att.AuthData.AttData.CredentialPublicKey, &key)
 
 	if webauthncose.COSEAlgorithmIdentifier(key.PublicKeyData.Algorithm) != webauthncose.AlgES256 {
 		return u2fAttestationKey, nil, ErrUnsupportedAlgorithm.WithDetails("Non-ES256 Public Key algorithm used")

--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -4,8 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-
-	"github.com/fxamacker/cbor/v2"
+	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 )
 
 var minAuthDataLength = 37
@@ -199,8 +198,8 @@ func (a *AuthenticatorData) unmarshalAttestedData(rawAuthData []byte) {
 // Unmarshall the credential's Public Key into CBOR encoding
 func unmarshalCredentialPublicKey(keyBytes []byte) []byte {
 	var m interface{}
-	cbor.Unmarshal(keyBytes, &m)
-	rawBytes, _ := cbor.Marshal(m)
+	webauthncbor.Unmarshal(keyBytes, &m)
+	rawBytes, _ := webauthncbor.Marshal(m)
 	return rawBytes
 }
 

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -3,12 +3,11 @@ package protocol
 import (
 	"bytes"
 	"encoding/base64"
+	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
-
-	"github.com/fxamacker/cbor/v2"
 )
 
 func TestParseCredentialCreationResponse(t *testing.T) {
@@ -113,10 +112,10 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 			// Unmarshall CredentialPublicKey
 			var pkWant interface{}
 			keyBytesWant := tt.want.Response.AttestationObject.AuthData.AttData.CredentialPublicKey
-			cbor.Unmarshal(keyBytesWant, &pkWant)
+			webauthncbor.Unmarshal(keyBytesWant, &pkWant)
 			var pkGot interface{}
 			keyBytesGot := got.Response.AttestationObject.AuthData.AttData.CredentialPublicKey
-			cbor.Unmarshal(keyBytesGot, &pkGot)
+			webauthncbor.Unmarshal(keyBytesGot, &pkGot)
 			if !reflect.DeepEqual(pkGot, pkWant) {
 				t.Errorf("Response = %+v \n want: %+v", pkGot, pkWant)
 			}

--- a/protocol/webauthncbor/webauthncbor.go
+++ b/protocol/webauthncbor/webauthncbor.go
@@ -1,0 +1,30 @@
+package webauthncbor
+
+import "github.com/fxamacker/cbor/v2"
+
+const nestedLevelsAllowed = 4
+
+// ctap2CBORDecMode is the cbor.DecMode following the CTAP2 canonical CBOR encoding form
+// (https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding)
+var ctap2CBORDecMode, _ = cbor.DecOptions{
+	DupMapKey:       cbor.DupMapKeyEnforcedAPF,
+	MaxNestedLevels: nestedLevelsAllowed,
+	IndefLength:     cbor.IndefLengthForbidden,
+	TagsMd:          cbor.TagsForbidden,
+}.DecMode()
+
+var ctap2CBOREncMode, _ = cbor.CTAP2EncOptions().EncMode()
+
+// Unmarshal parses the CBOR-encoded data into the value pointed to by v
+// following the CTAP2 canonical CBOR encoding form.
+// (https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding)
+func Unmarshal(data []byte, v interface{}) error {
+	return ctap2CBORDecMode.Unmarshal(data, v)
+}
+
+// Marshal encodes the value pointed to by v
+// following the CTAP2 canonical CBOR encoding form.
+// (https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding)
+func Marshal(v interface{}) ([]byte, error) {
+	return ctap2CBOREncMode.Marshal(v)
+}

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -9,12 +9,11 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
+	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 	"hash"
 	"math/big"
 
 	"golang.org/x/crypto/ed25519"
-
-	"github.com/fxamacker/cbor/v2"
 )
 
 // PublicKeyData The public key portion of a Relying Party-specific credential key pair, generated
@@ -160,21 +159,21 @@ func HasherFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) func() hash.Hash {
 // Figure out what kind of COSE material was provided and create the data for the new key
 func ParsePublicKey(keyBytes []byte) (interface{}, error) {
 	pk := PublicKeyData{}
-	cbor.Unmarshal(keyBytes, &pk)
+	webauthncbor.Unmarshal(keyBytes, &pk)
 	switch COSEKeyType(pk.KeyType) {
 	case OctetKey:
 		var o OKPPublicKeyData
-		cbor.Unmarshal(keyBytes, &o)
+		webauthncbor.Unmarshal(keyBytes, &o)
 		o.PublicKeyData = pk
 		return o, nil
 	case EllipticKey:
 		var e EC2PublicKeyData
-		cbor.Unmarshal(keyBytes, &e)
+		webauthncbor.Unmarshal(keyBytes, &e)
 		e.PublicKeyData = pk
 		return e, nil
 	case RSAKey:
 		var r RSAPublicKeyData
-		cbor.Unmarshal(keyBytes, &r)
+		webauthncbor.Unmarshal(keyBytes, &r)
 		r.PublicKeyData = pk
 		return r, nil
 	default:
@@ -372,7 +371,7 @@ var (
 		Details: "Unsupported public key algorithm",
 	}
 	ErrSigNotProvidedOrInvalid = &Error{
-		Type: "signature_not_provided_or_invalid",
+		Type:    "signature_not_provided_or_invalid",
 		Details: "Signature invalid or not provided",
 	}
 )

--- a/protocol/webauthncose/webauthncose_test.go
+++ b/protocol/webauthncose/webauthncose_test.go
@@ -2,9 +2,9 @@ package webauthncose
 
 import (
 	"crypto/rand"
+	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -58,7 +58,7 @@ MCowBQYDK2VwAyEAe4gQJK3JgtOAuHceO5v45LOZi8fQWDBmAs5NDy/kt4E=
 		},
 	}
 	// Get the CBOR-encoded representation of the OKPPublicKeyData
-	buf, _ := cbor.Marshal(key)
+	buf, _ := webauthncbor.Marshal(key)
 
 	got := DisplayPublicKey(buf)
 	if got != expected {


### PR DESCRIPTION
As stated in #78, currently the server accepts CBOR messages even if they do not follow the [CTAP2 canonical CBOR encoding form](https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding). Therefore I added `webauthncbor/webauthncbor.go` which provides wrapper functions for [fxamacker/cbor](https://github.com/fxamacker/cbor) with encoding/decoding options following the CTAP2 canonical CBOR encoding form.