### PR TITLE
Do not update Sign Count if authenticator clone is detected.

### DIFF
--- a/webauthn/authenticator.go
+++ b/webauthn/authenticator.go
@@ -45,6 +45,7 @@ func SelectAuthenticator(att string, rrk *bool, uv string) p.AuthenticatorSelect
 func (a *Authenticator) UpdateCounter(authDataCount uint32) {
 	if authDataCount <= a.SignCount && (authDataCount != 0 || a.SignCount != 0) {
 		a.CloneWarning = true
+		return
 	}
 	a.SignCount = authDataCount
 }

--- a/webauthn/authenticator_test.go
+++ b/webauthn/authenticator_test.go
@@ -90,9 +90,23 @@ func TestAuthenticator_UpdateCounter(t *testing.T) {
 				SignCount:    tt.fields.SignCount,
 				CloneWarning: tt.fields.CloneWarning,
 			}
+
+			previousSignCount := a.SignCount
 			a.UpdateCounter(tt.args.authDataCount)
 			if a.CloneWarning != tt.wantWarning {
 				t.Errorf("Clone warning result [%v] does not match expectation: [%v]", a.CloneWarning, tt.wantWarning)
+				return
+			}
+
+			// If there's no clone warning then, assert that the SignCount is updated
+			if !a.CloneWarning && a.SignCount != tt.args.authDataCount {
+				t.Errorf("Sign Count value [%v] does not match expectation [%v]", a.SignCount, tt.args.authDataCount)
+				return
+			}
+
+			// If there's clone warning then, assert that the Sign Count remains unchanged
+			if a.CloneWarning && a.SignCount != previousSignCount {
+				t.Errorf("Sign Count value [%v] does not match expectation [%v]", a.SignCount, tt.args.authDataCount)
 				return
 			}
 		})


### PR DESCRIPTION
A cloned authenticator can decrement the sign count value leading to the logic failing to detect clone in future.