### PR TITLE
Use Canonical Encoding for re-marshalling credential unmarshal step

### DIFF
--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -200,7 +200,8 @@ func (a *AuthenticatorData) unmarshalAttestedData(rawAuthData []byte) {
 func unmarshalCredentialPublicKey(keyBytes []byte) []byte {
 	var m interface{}
 	cbor.Unmarshal(keyBytes, &m)
-	rawBytes, _ := cbor.Marshal(m)
+	encMode, _ := cbor.CTAP2EncOptions().EncMode()
+	rawBytes, _ := encMode.Marshal(m)
 	return rawBytes
 }
 


### PR DESCRIPTION
`Marshal` seems  to be unstable. Instead use `CTAP2Encoding` as per the Webauthn spec.  


cbor.Marshal doesn't seem to be stable across runs.  It produces
different keyBytes on subsequent calls with the same input which is
extremely confusing if you're inspecting the attestation data directly
and comparing it to previous attestations.

Swap out for canonical Marshal as per Webauthn spec which uses a stable
ordering of map elements.


Overall I'm confused why this step is made in the first place. We're not doing any error handling. what happens if Unmarshal fails? It will try to marshal `nil` in that case. 

Why do we not pass the `rawBytes` through untouched to the rest of the code?

