### PR TITLE
fix: missing extension results in parsed credential data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/duo-labs/webauthn
 
 require (
 	github.com/cloudflare/cfssl v0.0.0-20190726000631-633726f6bcb7
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fxamacker/cbor/v2 v2.2.0
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/certificate-transparency-go v1.0.21 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,15 @@
 github.com/cloudflare/cfssl v0.0.0-20190726000631-633726f6bcb7 h1:Puu1hUwfps3+1CUzYdAZXijuvLuRMirgiXdf3zsM2Ig=
 github.com/cloudflare/cfssl v0.0.0-20190726000631-633726f6bcb7/go.mod h1:yMWuSON2oQp+43nFtAV/uvKQIFpSPerB57DCt9t8sSA=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
 github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
 github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/google/certificate-transparency-go v1.0.21 h1:Yf1aXowfZ2nuboBsg7iYGLmwsOARdV86pfH3g95wXmE=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -23,4 +24,5 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	uuid "github.com/satori/go.uuid"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // Metadata is a map of authenticator AAGUIDs to corresponding metadata statements

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -11,10 +11,9 @@ import (
 	"net/http"
 
 	"github.com/cloudflare/cfssl/revoke"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/mitchellh/mapstructure"
 	uuid "github.com/satori/go.uuid"
-
-	"github.com/golang-jwt/jwt/v4"
 )
 
 // Metadata is a map of authenticator AAGUIDs to corresponding metadata statements

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -52,7 +52,9 @@ func TestMetadataTOCParsing(t *testing.T) {
 			b, _ := ioutil.ReadFile(tt.file)
 			_, _, err := unmarshalMDSTOC(b, *httpClient)
 			failed := true
-			if err != nil {
+			if tt.wantErr == nil {
+				failed = err != nil
+			} else if err != nil {
 				failed = (err.Error() != tt.wantErr.Error())
 			} else {
 				failed = tt.wantErr != nil

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 func TestMetadataTOCParsing(t *testing.T) {

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -94,8 +94,8 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 				t.Errorf("ParseCredentialRequestResponse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got.Extensions, tt.want.Extensions) {
-				t.Errorf("Extensions = %v \n want: %v", got, tt.want)
+			if !reflect.DeepEqual(got.ClientExtensionResults, tt.want.ClientExtensionResults) {
+				t.Errorf("ClientExtensionResults = %v \n want: %v", got, tt.want)
 			}
 			if !reflect.DeepEqual(got.ID, tt.want.ID) {
 				t.Errorf("ID = %v \n want: %v", got.ID, tt.want.ID)
@@ -104,7 +104,7 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 				t.Errorf("ParsedCredential = %v \n want: %v", got, tt.want)
 			}
 			if !reflect.DeepEqual(got.ParsedPublicKeyCredential, tt.want.ParsedPublicKeyCredential) {
-				t.Errorf("ParsedPublicKeyCredential = %v \n want: %v", got.ParsedPublicKeyCredential.Extensions, tt.want.ParsedPublicKeyCredential.Extensions)
+				t.Errorf("ParsedPublicKeyCredential = %v \n want: %v", got.ParsedPublicKeyCredential.ClientExtensionResults, tt.want.ParsedPublicKeyCredential.ClientExtensionResults)
 			}
 			if !reflect.DeepEqual(got.Raw, tt.want.Raw) {
 				t.Errorf("Raw = %+v \n want: %+v", got.Raw, tt.want.Raw)
@@ -172,7 +172,8 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 				Response:                  tt.fields.Response,
 				Raw:                       tt.fields.Raw,
 			}
-			if err := p.Verify(tt.args.storedChallenge.String(), tt.args.relyingPartyID, tt.args.relyingPartyOrigin, tt.args.verifyUser, tt.args.credentialBytes); (err != nil) != tt.wantErr {
+
+			if err := p.Verify(tt.args.storedChallenge.String(), tt.args.relyingPartyID, tt.args.relyingPartyOrigin, "", tt.args.verifyUser, tt.args.credentialBytes); (err != nil) != tt.wantErr {
 				t.Errorf("ParsedCredentialAssertionData.Verify() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -115,7 +115,7 @@ func (attestationObject *AttestationObject) Verify(relyingPartyID string, client
 	// the SHA-256 hash of the RP ID expected by the RP.
 	rpIDHash := sha256.Sum256([]byte(relyingPartyID))
 	// Handle Steps 9 through 12
-	authDataVerificationError := attestationObject.AuthData.Verify(rpIDHash[:], verificationRequired)
+	authDataVerificationError := attestationObject.AuthData.Verify(rpIDHash[:], nil, verificationRequired)
 	if authDataVerificationError != nil {
 		return authDataVerificationError
 	}

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/duo-labs/webauthn/metadata"
 	uuid "github.com/satori/go.uuid"
 
+	"github.com/duo-labs/webauthn/metadata"
 	"github.com/duo-labs/webauthn/protocol/webauthncose"
 )
 

--- a/protocol/attestation_safetynet.go
+++ b/protocol/attestation_safetynet.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/duo-labs/webauthn/metadata"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/mitchellh/mapstructure"
 )
 

--- a/protocol/attestation_safetynet.go
+++ b/protocol/attestation_safetynet.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/duo-labs/webauthn/metadata"
-
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/duo-labs/webauthn/metadata"
 )
 
 var safetyNetAttestationKey = "android-safetynet"

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -19,7 +19,7 @@ func TestAttestationVerify(t *testing.T) {
 				t.Fatal(err)
 			}
 			var pcc ParsedCredentialCreationData
-			pcc.ID, pcc.RawID, pcc.Type = ccr.ID, ccr.RawID, ccr.Type
+			pcc.ID, pcc.RawID, pcc.Type, pcc.ClientExtensionResults = ccr.ID, ccr.RawID, ccr.Type, ccr.ClientExtensionResults
 			pcc.Raw = ccr
 
 			parsedAttestationResponse, err := ccr.AttestationResponse.Parse()
@@ -52,7 +52,7 @@ func attestationTestUnpackResponse(t *testing.T, response string) ParsedCredenti
 		t.Fatal(err)
 	}
 	var pcc ParsedCredentialCreationData
-	pcc.ID, pcc.RawID, pcc.Type = ccr.ID, ccr.RawID, ccr.Type
+	pcc.ID, pcc.RawID, pcc.Type, pcc.ClientExtensionResults = ccr.ID, ccr.RawID, ccr.Type, ccr.ClientExtensionResults
 	pcc.Raw = ccr
 
 	parsedAttestationResponse, err := ccr.AttestationResponse.Parse()

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -10,9 +10,8 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/duo-labs/webauthn/protocol/webauthncose"
-
 	"github.com/duo-labs/webauthn/protocol/googletpm"
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
 )
 
 var tpmAttestationKey = "tpm"

--- a/protocol/attestation_u2f.go
+++ b/protocol/attestation_u2f.go
@@ -6,8 +6,9 @@ import (
 	"crypto/elliptic"
 	"crypto/x509"
 
-	"github.com/duo-labs/webauthn/protocol/webauthncose"
 	"github.com/fxamacker/cbor/v2"
+
+	"github.com/duo-labs/webauthn/protocol/webauthncose"
 )
 
 var u2fAttestationKey = "fido-u2f"

--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -177,7 +177,7 @@ func (a *AuthenticatorData) Unmarshal(rawAuthData []byte) error {
 			a.ExtData = rawAuthData[len(rawAuthData)-remaining:]
 			remaining -= len(a.ExtData)
 		} else {
-			return ErrBadRequest.WithDetails("Extensions flag set but extensions data is missing")
+			return ErrBadRequest.WithDetails("ClientExtensionResults flag set but extensions data is missing")
 		}
 	}
 
@@ -218,12 +218,12 @@ func ResidentKeyUnrequired() *bool {
 
 // Verify on AuthenticatorData handles Steps 9 through 12 for Registration
 // and Steps 11 through 14 for Assertion.
-func (a *AuthenticatorData) Verify(rpIdHash []byte, userVerificationRequired bool) error {
+func (a *AuthenticatorData) Verify(rpIdHash []byte, appIDHash []byte, userVerificationRequired bool) error {
 
 	// Registration Step 9 & Assertion Step 11
 	// Verify that the RP ID hash in authData is indeed the SHA-256
 	// hash of the RP ID expected by the RP.
-	if !bytes.Equal(a.RPIDHash[:], rpIdHash) {
+	if !bytes.Equal(a.RPIDHash[:], rpIdHash) && appIDHash != nil && !bytes.Equal(a.RPIDHash[:], appIDHash) {
 		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %+s and Received %+s\n", a.RPIDHash, rpIdHash))
 	}
 

--- a/protocol/authenticator_test.go
+++ b/protocol/authenticator_test.go
@@ -253,7 +253,7 @@ func TestAuthenticatorData_Verify(t *testing.T) {
 				AttData:  tt.fields.AttData,
 				ExtData:  tt.fields.ExtData,
 			}
-			if err := a.Verify(tt.args.rpIdHash, tt.args.userVerificationRequired); (err != nil) != tt.wantErr {
+			if err := a.Verify(tt.args.rpIdHash, nil, tt.args.userVerificationRequired); (err != nil) != tt.wantErr {
 				t.Errorf("AuthenticatorData.Verify() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/protocol/base64.go
+++ b/protocol/base64.go
@@ -13,7 +13,7 @@ type URLEncodedBase64 []byte
 
 // UnmarshalJSON base64 decodes a URL-encoded value, storing the result in the
 // provided byte slice.
-func (dest *URLEncodedBase64) UnmarshalJSON(data []byte) error {
+func (e *URLEncodedBase64) UnmarshalJSON(data []byte) error {
 	if bytes.Equal(data, []byte("null")) {
 		return nil
 	}
@@ -26,16 +26,16 @@ func (dest *URLEncodedBase64) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	v := reflect.ValueOf(dest).Elem()
+	v := reflect.ValueOf(e).Elem()
 	v.SetBytes(out[:n])
 	return nil
 }
 
 // MarshalJSON base64 encodes a non URL-encoded value, storing the result in the
 // provided byte slice.
-func (data URLEncodedBase64) MarshalJSON() ([]byte, error) {
-	if data == nil {
+func (e URLEncodedBase64) MarshalJSON() ([]byte, error) {
+	if e == nil {
 		return []byte("null"), nil
 	}
-	return []byte(`"` + base64.RawURLEncoding.EncodeToString(data) + `"`), nil
+	return []byte(`"` + base64.RawURLEncoding.EncodeToString(e) + `"`), nil
 }

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -32,14 +32,14 @@ type ParsedCredential struct {
 
 type PublicKeyCredential struct {
 	Credential
-	RawID      URLEncodedBase64                      `json:"rawId"`
-	Extensions AuthenticationExtensionsClientOutputs `json:"extensions,omitempty"`
+	RawID                  URLEncodedBase64                      `json:"rawId"`
+	ClientExtensionResults AuthenticationExtensionsClientOutputs `json:"clientExtensionResults,omitempty"`
 }
 
 type ParsedPublicKeyCredential struct {
 	ParsedCredential
-	RawID      []byte                                `json:"rawId"`
-	Extensions AuthenticationExtensionsClientOutputs `json:"extensions,omitempty"`
+	RawID                  []byte                                `json:"rawId"`
+	ClientExtensionResults AuthenticationExtensionsClientOutputs `json:"clientExtensionResults,omitempty"`
 }
 
 type CredentialCreationResponse struct {
@@ -159,4 +159,58 @@ func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUs
 	// TODO: Not implemented for the reasons mentioned under Step 16
 
 	return nil
+}
+
+// GetAppID takes a AuthenticationExtensions object or nil. It then performs the following checks in order:
+//
+// 1. Check that the Session Data's AuthenticationExtensions has been provided and if it hasn't return an error.
+// 2. Check that the AuthenticationExtensionsClientOutputs contains the extensions output and return an empty string if it doesn't.
+// 3. Check that the Credential AttestationType is `fido-u2f` and return an empty string if it isn't.
+// 4. Check that the AuthenticationExtensionsClientOutputs contains the appid key and if it doesn't return an empty string.
+// 5. Check that the AuthenticationExtensionsClientOutputs appid is a bool and if it isn't return an error.
+// 6. Check that the appid output is true and if it isn't return an empty string.
+// 7. Check that the Session Data has an appid extension defined and if it doesn't return an error.
+// 8. Check that the appid extension in Session Data is a string and if it isn't return an error.
+// 9. Return the appid extension value from the Session data.
+func (ppkc ParsedPublicKeyCredential) GetAppID(authExt AuthenticationExtensions, credentialAttestationType string) (appID string, err error) {
+	var (
+		value, clientValue interface{}
+		enableAppID, ok    bool
+	)
+
+	if authExt == nil {
+		return "", nil
+	}
+
+	if ppkc.ClientExtensionResults == nil {
+		return "", nil
+	}
+
+	// If the credential does not have the correct attestation type it is assumed to NOT be a fido-u2f credential.
+	// https://w3c.github.io/webauthn/#sctn-fido-u2f-attestation
+	if credentialAttestationType != "fido-u2f" {
+		return "", nil
+	}
+
+	if clientValue, ok = ppkc.ClientExtensionResults["appid"]; ok {
+		if enableAppID, ok = clientValue.(bool); !ok {
+			return "", ErrBadRequest.WithDetails("Client Output appid did not have the expected type")
+		}
+
+		if !enableAppID {
+			return "", nil
+		}
+
+		if value, ok = authExt["appid"]; !ok {
+			return "", ErrBadRequest.WithDetails("Session Data does not have an appid but Client Output indicates it should be set")
+		}
+
+		if appID, ok = value.(string); !ok {
+			return "", ErrBadRequest.WithDetails("Session Data appid did not have the expected type")
+		}
+
+		return appID, nil
+	}
+
+	return "", nil
 }

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -85,7 +85,7 @@ func ParseCredentialCreationResponseBody(body io.Reader) (*ParsedCredentialCreat
 	}
 
 	var pcc ParsedCredentialCreationData
-	pcc.ID, pcc.RawID, pcc.Type = ccr.ID, ccr.RawID, ccr.Type
+	pcc.ID, pcc.RawID, pcc.Type, pcc.ClientExtensionResults = ccr.ID, ccr.RawID, ccr.Type, ccr.ClientExtensionResults
 	pcc.Raw = ccr
 
 	parsedAttestationResponse, err := ccr.AttestationResponse.Parse()

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -92,8 +92,8 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 				t.Errorf("ParseCredentialCreationResponse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got.Extensions, tt.want.Extensions) {
-				t.Errorf("Extensions = %v \n want: %v", got, tt.want)
+			if !reflect.DeepEqual(got.ClientExtensionResults, tt.want.ClientExtensionResults) {
+				t.Errorf("ClientExtensionResults = %v \n want: %v", got, tt.want)
 			}
 			if !reflect.DeepEqual(got.ID, tt.want.ID) {
 				t.Errorf("ID = %v \n want: %v", got, tt.want)

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -68,18 +68,18 @@ var (
 	}
 )
 
-func (err *Error) Error() string {
-	return err.Details
+func (e *Error) Error() string {
+	return e.Details
 }
 
-func (passedError *Error) WithDetails(details string) *Error {
-	err := *passedError
+func (e *Error) WithDetails(details string) *Error {
+	err := *e
 	err.Details = details
 	return &err
 }
 
-func (passedError *Error) WithInfo(info string) *Error {
-	err := *passedError
+func (e *Error) WithInfo(info string) *Error {
+	err := *e
 	err.DevInfo = info
 	return &err
 }

--- a/protocol/extensions.go
+++ b/protocol/extensions.go
@@ -2,7 +2,7 @@ package protocol
 
 // Extensions are discussed in §9. WebAuthn Extensions (https://www.w3.org/TR/webauthn/#extensions).
 
-// For a list of commonly supported extenstions, see §10. Defined Extensions 
+// For a list of commonly supported extenstions, see §10. Defined Extensions
 // (https://www.w3.org/TR/webauthn/#sctn-defined-extensions).
 
 type AuthenticationExtensionsClientOutputs map[interface{}]interface{}

--- a/protocol/extensions.go
+++ b/protocol/extensions.go
@@ -2,7 +2,7 @@ package protocol
 
 // Extensions are discussed in §9. WebAuthn Extensions (https://www.w3.org/TR/webauthn/#extensions).
 
-// For a list of commonly supported extenstions, see §10. Defined Extensions
+// For a list of commonly supported extensions, see §10. Defined Extensions
 // (https://www.w3.org/TR/webauthn/#sctn-defined-extensions).
 
-type AuthenticationExtensionsClientOutputs map[interface{}]interface{}
+type AuthenticationExtensionsClientOutputs map[string]interface{}

--- a/protocol/signature_algorithms.go
+++ b/protocol/signature_algorithms.go
@@ -1,1 +1,0 @@
-package protocol

--- a/protocol/webauthncose/ed25519.go
+++ b/protocol/webauthncose/ed25519.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 package webauthncose

--- a/protocol/webauthncose/ed25519_go112.go
+++ b/protocol/webauthncose/ed25519_go112.go
@@ -1,3 +1,4 @@
+//go:build !go1.13
 // +build !go1.13
 
 package webauthncose

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -12,9 +12,8 @@ import (
 	"hash"
 	"math/big"
 
-	"golang.org/x/crypto/ed25519"
-
 	"github.com/fxamacker/cbor/v2"
+	"golang.org/x/crypto/ed25519"
 )
 
 // PublicKeyData The public key portion of a Relying Party-specific credential key pair, generated
@@ -372,7 +371,7 @@ var (
 		Details: "Unsupported public key algorithm",
 	}
 	ErrSigNotProvidedOrInvalid = &Error{
-		Type: "signature_not_provided_or_invalid",
+		Type:    "signature_not_provided_or_invalid",
 		Details: "Signature invalid or not provided",
 	}
 )

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -181,6 +181,19 @@ func ParsePublicKey(keyBytes []byte) (interface{}, error) {
 	}
 }
 
+func ParseFIDOPublicKey(keyBytes []byte) (EC2PublicKeyData, error) {
+	x, y := elliptic.Unmarshal(elliptic.P256(), keyBytes)
+
+	return EC2PublicKeyData{
+		PublicKeyData: PublicKeyData{
+			Algorithm: int64(AlgES256),
+			KeyType:   int64(EllipticKey),
+		},
+		XCoord: x.Bytes(),
+		YCoord: y.Bytes(),
+	}, nil
+}
+
 // COSEAlgorithmIdentifier From §5.10.5. A number identifying a cryptographic algorithm. The algorithm
 // identifiers SHOULD be values registered in the IANA COSE Algorithms registry
 // [https://www.w3.org/TR/webauthn/#biblio-iana-cose-algs-reg], for instance, -7 for "ES256"

--- a/webauthn/authenticator.go
+++ b/webauthn/authenticator.go
@@ -45,6 +45,7 @@ func SelectAuthenticator(att string, rrk *bool, uv string) p.AuthenticatorSelect
 func (a *Authenticator) UpdateCounter(authDataCount uint32) {
 	if authDataCount <= a.SignCount && (authDataCount != 0 || a.SignCount != 0) {
 		a.CloneWarning = true
+		return
 	}
 	a.SignCount = authDataCount
 }

--- a/webauthn/authenticator_test.go
+++ b/webauthn/authenticator_test.go
@@ -90,9 +90,23 @@ func TestAuthenticator_UpdateCounter(t *testing.T) {
 				SignCount:    tt.fields.SignCount,
 				CloneWarning: tt.fields.CloneWarning,
 			}
+
+			previousSignCount := a.SignCount
 			a.UpdateCounter(tt.args.authDataCount)
 			if a.CloneWarning != tt.wantWarning {
 				t.Errorf("Clone warning result [%v] does not match expectation: [%v]", a.CloneWarning, tt.wantWarning)
+				return
+			}
+
+			// If there's no clone warning then, assert that the SignCount is updated
+			if !a.CloneWarning && a.SignCount != tt.args.authDataCount {
+				t.Errorf("Sign Count value [%v] does not match expectation [%v]", a.SignCount, tt.args.authDataCount)
+				return
+			}
+
+			// If there's clone warning then, assert that the Sign Count remains unchanged
+			if a.CloneWarning && a.SignCount != previousSignCount {
+				t.Errorf("Sign Count value [%v] does not match expectation [%v]", a.SignCount, tt.args.authDataCount)
 				return
 			}
 		})

--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -21,7 +21,6 @@ type Credential struct {
 
 // MakeNewCredential will return a credential pointer on successful validation of a registration response
 func MakeNewCredential(c *protocol.ParsedCredentialCreationData) (*Credential, error) {
-
 	newCredential := &Credential{
 		ID:              c.Response.AttestationObject.AuthData.AttData.CredentialID,
 		PublicKey:       c.Response.AttestationObject.AuthData.AttData.CredentialPublicKey,

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -108,7 +108,7 @@ func (webauthn *WebAuthn) ValidateLogin(user User, session SessionData, parsedRe
 	// verify that credential.id identifies one of the public key credentials that were listed in
 	// allowCredentials.
 
-	// NON-NORMATIVE Prior Step: Verify that the allowCredentials for the sesssion are owned by the user provided
+	// NON-NORMATIVE Prior Step: Verify that the allowCredentials for the session are owned by the user provided
 	userCredentials := user.WebAuthnCredentials()
 	var credentialFound bool
 	if len(session.AllowedCredentialIDs) > 0 {

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -59,6 +59,7 @@ func (webauthn *WebAuthn) BeginLogin(user User, opts ...LoginOption) (*protocol.
 		UserID:               user.WebAuthnID(),
 		AllowedCredentialIDs: requestOptions.GetAllowedCredentialIDs(),
 		UserVerification:     requestOptions.UserVerification,
+		Extensions:           requestOptions.Extensions,
 	}
 
 	response := protocol.CredentialAssertion{requestOptions}
@@ -169,8 +170,13 @@ func (webauthn *WebAuthn) ValidateLogin(user User, session SessionData, parsedRe
 	rpID := webauthn.Config.RPID
 	rpOrigin := webauthn.Config.RPOrigin
 
+	appID, err := parsedResponse.GetAppID(session.Extensions, loginCredential.AttestationType)
+	if err != nil {
+		return nil, err
+	}
+
 	// Handle steps 4 through 16
-	validError := parsedResponse.Verify(session.Challenge, rpID, rpOrigin, shouldVerifyUser, loginCredential.PublicKey)
+	validError := parsedResponse.Verify(session.Challenge, rpID, rpOrigin, appID, shouldVerifyUser, loginCredential.PublicKey)
 	if validError != nil {
 		return nil, validError
 	}

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -113,8 +113,8 @@ func (webauthn *WebAuthn) ValidateLogin(user User, session SessionData, parsedRe
 	var credentialFound bool
 	if len(session.AllowedCredentialIDs) > 0 {
 		var credentialsOwned bool
-		for _, userCredential := range userCredentials {
-			for _, allowedCredentialID := range session.AllowedCredentialIDs {
+		for _, allowedCredentialID := range session.AllowedCredentialIDs {
+			for _, userCredential := range userCredentials {
 				if bytes.Equal(userCredential.ID, allowedCredentialID) {
 					credentialsOwned = true
 					break

--- a/webauthn/main.go
+++ b/webauthn/main.go
@@ -57,6 +57,15 @@ func (config *Config) validate() error {
 		config.RPOrigin = protocol.FullyQualifiedOrigin(u)
 	}
 
+	if config.AuthenticatorSelection.RequireResidentKey == nil {
+		rrk := false
+		config.AuthenticatorSelection.RequireResidentKey = &rrk
+	}
+
+	if config.AuthenticatorSelection.UserVerification == "" {
+		config.AuthenticatorSelection.UserVerification = protocol.VerificationPreferred
+	}
+
 	return nil
 }
 

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -126,43 +126,43 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 
 func defaultRegistrationCredentialParameters() []protocol.CredentialParameter {
 	return []protocol.CredentialParameter{
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgES256,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgES384,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgES512,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgRS256,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgRS384,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgRS512,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgPS256,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgPS384,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgPS512,
 		},
-		protocol.CredentialParameter{
+		{
 			Type:      protocol.PublicKeyCredentialType,
 			Algorithm: webauthncose.AlgEdDSA,
 		},

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/duo-labs/webauthn/protocol"
 )
 
-
 func TestRegistration_FinishRegistrationFailure(t *testing.T) {
 	user := &defaultUser{
 		id: []byte("123"),

--- a/webauthn/session.go
+++ b/webauthn/session.go
@@ -9,4 +9,5 @@ type SessionData struct {
 	UserID               []byte                               `json:"user_id"`
 	AllowedCredentialIDs [][]byte                             `json:"allowed_credentials,omitempty"`
 	UserVerification     protocol.UserVerificationRequirement `json:"userVerification"`
+	Extensions           protocol.AuthenticationExtensions    `json:"extensions,omitempty"`
 }


### PR DESCRIPTION
This ensures the ClientExtensionResults in the response are properly copied to the parsed results.