### PR TITLE
Fix error wrapping in assertion

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -119,7 +119,7 @@ func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPa
 	// Handle steps 11 through 14, verifying the authenticator data.
 	validError = p.Response.AuthenticatorData.Verify(rpIDHash[:], verifyUser)
 	if validError != nil {
-		return ErrAuthData.WithInfo(validError.Error())
+		return validError
 	}
 
 	// allowedUserCredentialIDs := session.AllowedCredentialIDs


### PR DESCRIPTION
This error is being wrapped twice, the `Verify` function already returns errors with `ErrVerification.WithInfo`