### PR TITLE
Fix panic on invalid client data

### DIFF
--- a/protocol/authenticator_test.go
+++ b/protocol/authenticator_test.go
@@ -184,9 +184,10 @@ func TestAuthenticatorData_unmarshalAttestedData(t *testing.T) {
 		rawAuthData []byte
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
 	}{
 		// TODO: Add test cases.
 	}
@@ -199,7 +200,9 @@ func TestAuthenticatorData_unmarshalAttestedData(t *testing.T) {
 				AttData:  tt.fields.AttData,
 				ExtData:  tt.fields.ExtData,
 			}
-			a.unmarshalAttestedData(tt.args.rawAuthData)
+			if err := a.unmarshalAttestedData(tt.args.rawAuthData); (err != nil) != tt.wantErr {
+				t.Errorf("AuthenticatorData.unmarshalAttestedData() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Invalid data from the client will cause the server to panic from unchecked lengths