### PR TITLE
fix `conveyancePref` varible name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ func beginRegistration() {
 
     // Updating the ConveyencePreference options. 
     // See the struct declarations for values
-    conveyencePref := protocol.ConveyancePreference(protocol.PreferNoAttestation)
+    conveyancePref := protocol.ConveyancePreference(protocol.PreferNoAttestation)
 
     user := datastore.GetUser() // Get the user  
     opts, sessionData, err webAuthnHandler.BeginRegistration(&user, webauthn.WithAuthenticatorSelection(authSelect), webauthn.WithConveyancePreference(conveyancePref))


### PR DESCRIPTION
The variable name of `conveyencePref` is fixed as `conveyancePref`