### PR TITLE
fix(protocol): potential panic in u2f format

### DIFF
--- a/protocol/attestation_u2f.go
+++ b/protocol/attestation_u2f.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
+	"fmt"
+
 	"github.com/duo-labs/webauthn/protocol/webauthncbor"
 
 	"github.com/duo-labs/webauthn/protocol/webauthncose"
@@ -127,7 +129,7 @@ func verifyU2FFormat(att AttestationObject, clientDataHash []byte) (string, []in
 	// Step 6. Verify the sig using verificationData and certificate public key per SEC1[https://www.w3.org/TR/webauthn/#biblio-sec1].
 	sigErr := attCert.CheckSignature(x509.ECDSAWithSHA256, verificationData.Bytes(), signature)
 	if sigErr != nil {
-		return u2fAttestationKey, nil, sigErr
+		return u2fAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", sigErr))
 	}
 
 	// Step 7. If successful, return attestation type Basic with the attestation trust path set to x5c.


### PR DESCRIPTION
This fixes a potential panic caused by the U2F attestation format due to it returning a non protocol error. It uses the same return format as most other attestation format handlers.

Fixes #147