### PR TITLE
Remove unnecessary space in ParsedCredential docs

### DIFF
--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -23,7 +23,7 @@ type Credential struct {
 }
 
 // The PublicKeyCredential interface inherits from Credential, and contains
-//  the attributes that are returned to the caller when a new credential
+// the attributes that are returned to the caller when a new credential
 // is created, or a new assertion is requested.
 type ParsedCredential struct {
 	ID   string `cbor:"id"`


### PR DESCRIPTION
Just noticed it in IDE because of weird formatting with extra space.
