### PR TITLE
fix(doc): Fix a few typos in comments 

### DIFF
--- a/protocol/options.go
+++ b/protocol/options.go
@@ -12,7 +12,7 @@ type CredentialAssertion struct {
 	Response PublicKeyCredentialRequestOptions `json:"publicKey"`
 }
 
-// In order to create a Credential via create(), the caller specifies a few parameters in a CredentialCreationOptions object.
+// In order to create a Credential via create(), the caller specifies a few parameters in a PublicKeyCredentialCreationOptions object.
 // See §5.4. Options for Credential Creation https://www.w3.org/TR/webauthn/#dictionary-makecredentialoptions
 type PublicKeyCredentialCreationOptions struct {
 	Challenge              Challenge                `json:"challenge"`

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -8,8 +8,8 @@ import (
 	"github.com/duo-labs/webauthn/protocol"
 )
 
-// BEGIN REGISTRATION
-// These objects help us creat the CredentialCreationOptions
+// BEGIN LOGIN
+// These objects help us create the PublicKeyCredentialRequestOptions
 // that will be passed to the authenticator via the user client
 
 // LoginOption is used to provide parameters that modify the default Credential Assertion Payload that is sent to the user.

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BEGIN REGISTRATION
-// These objects help us creat the CredentialCreationOptions
+// These objects help us create the PublicKeyCredentialCreationOptions
 // that will be passed to the authenticator via the user client
 
 type RegistrationOption func(*protocol.PublicKeyCredentialCreationOptions)


### PR DESCRIPTION
Noticed a typo for `creat` and wanted to fix that. But I also noticed that we probably want to reference the specific `CredentialCreationOptions`? Hopefully these suggestions make sense and are reasonable!